### PR TITLE
feat: per-group caching and skip-if/require gating

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ type runtimeOpts struct {
 	configFile string
 	dryRun     bool
 	verbose    bool
+	noCache    bool
 
 	cfg *config.Config
 	log logger.Logger
@@ -82,7 +83,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newRunCmd(opts *runtimeOpts) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "run [flow]",
 		Short: "Execute a flow (uses the configured default when no flow is given)",
 		Args:  cobra.MaximumNArgs(1),
@@ -97,10 +98,13 @@ func newRunCmd(opts *runtimeOpts) *cobra.Command {
 			e := engine.New(opts.cfg,
 				engine.WithLogger(opts.log),
 				engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),
+				engine.WithNoCache(opts.noCache),
 			)
 			return e.RunFlow(cmd.Context(), flowName)
 		},
 	}
+	cmd.Flags().BoolVar(&opts.noCache, "no-cache", false, "Ignore cached results; run every group")
+	return cmd
 }
 
 func newListCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {
@@ -165,7 +169,8 @@ func printFlows(out io.Writer, cfg *config.Config) error {
 }
 
 func printGroups(out io.Writer, cfg *config.Config) error {
-	for _, g := range cfg.Groups {
+	for i := range cfg.Groups {
+		g := &cfg.Groups[i]
 		desc := g.Description
 		if desc == "" {
 			desc = noDescription

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -40,18 +40,20 @@ settings:
   dry-run: false # bool; default false. CLI --dry-run can override.
   working-dir: /tmp # string; reserved for future per-task chdir support.
   max-concurrency: 0 # int;   0 means unbounded.
+  cache-dir: .keepup-cache # string; where cache fingerprints are stored.
   logging:
     level: info # trace | debug | info | warn | error
     pretty: true # true = human; false = JSON lines.
 ```
 
-| Field             | Default         | Notes                                                                                                                         |
-| ----------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `dry-run`         | `false`         | When true, the runner is bypassed for every group. The CLI `--dry-run` flag also forces this on regardless of the file value. |
-| `working-dir`     | `""`            | Currently reserved. Not consumed by the runner yet.                                                                           |
-| `max-concurrency` | `0` (unbounded) | Caps the number of groups running concurrently across both step- and dag-mode schedulers.                                     |
-| `logging.level`   | `info`          | Standard severity ladder. Invalid values fall back to `info`.                                                                 |
-| `logging.pretty`  | `false`         | `true` for the human renderer, `false` for one JSON object per line.                                                          |
+| Field             | Default          | Notes                                                                                                                         |
+| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `dry-run`         | `false`          | When true, the runner is bypassed for every group. The CLI `--dry-run` flag also forces this on regardless of the file value. |
+| `working-dir`     | `""`             | Currently reserved. Not consumed by the runner yet.                                                                           |
+| `max-concurrency` | `0` (unbounded)  | Caps the number of groups running concurrently across both step- and dag-mode schedulers.                                     |
+| `cache-dir`       | `.keepup-cache`  | Directory where per-group cache fingerprints/outputs are stored (see [Caching](#caching)).                                    |
+| `logging.level`   | `info`           | Standard severity ladder. Invalid values fall back to `info`.                                                                 |
+| `logging.pretty`  | `false`          | `true` for the human renderer, `false` for one JSON object per line.                                                          |
 
 ---
 
@@ -94,6 +96,9 @@ groups:
 | `env`         | map        | no       | Per-group env overrides; applied on top of the global `env`.                                                            |
 | `shell`       | string     | no       | When non-empty, the named shell program runs `command + params` as a single shell-interpreted line (opt-in shell mode). |
 | `description` | string     | no       | Free text used by `keepup list groups`.                                                                                 |
+| `require`     | string     | no       | Predicate command; non-zero exit fails the group before it runs (see [Gating](#gating-skip-if-and-require)).             |
+| `skip-if`     | string     | no       | Predicate command; exit 0 skips the group (see [Gating](#gating-skip-if-and-require)).                                   |
+| `cache`       | map        | no       | Skip the group when declared inputs are unchanged (see [Caching](#caching)).                                            |
 
 ### Direct exec vs. shell mode
 
@@ -143,6 +148,64 @@ Reference rules:
 
 These rules are enforced at parse time (`keepup validate`), not at run time,
 so typos and ordering bugs surface immediately.
+
+### Gating: `skip-if` and `require`
+
+Two optional predicates let a group decide whether it should run. Both are
+shell snippets evaluated through the platform shell; only their exit status
+matters.
+
+```yaml
+groups:
+  - name: create-cache-dir
+    command: mkdir
+    params: [-p, /var/cache/app]
+    require: "command -v mkdir" # exit != 0 → hard fail before running
+    skip-if: "test -d /var/cache/app" # exit 0 → skip the group entirely
+```
+
+| Field | Meaning | On match |
+|-------|---------|----------|
+| `require` | Precondition that must hold | Non-zero exit → the group (and its flow) fails with a clear error. |
+| `skip-if` | Condition under which work is unnecessary | Exit 0 → the group is skipped; its output is the last cached value if `cache:` is set, otherwise empty. |
+
+Evaluation order per group: `require` → `skip-if` → `cache` → run. In
+`--dry-run`, predicates are **not** evaluated — keepup only logs what it would
+do.
+
+### Caching
+
+A `cache:` block lets keepup skip a group when its declared inputs haven't
+changed since the last successful run. On a hit, the runner is not invoked and
+the previously-captured output is replayed (so downstream `{{ output.X }}`
+references still resolve).
+
+```yaml
+groups:
+  - name: build
+    command: go
+    params: [build, -o, bin/keepup, ./]
+    cache:
+      method: hash # 'hash' (default) or 'mtime'
+      reads: ["**/*.go", "go.mod", "go.sum"] # inputs; globs support **
+      writes: ["bin/keepup"] # optional; must still exist for a hit
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `method` | `hash` | `hash` reads file contents (correct); `mtime` uses modtime+size (faster, coarser). |
+| `reads` | — (required) | Input paths/globs. The fingerprint also folds in `command` + `params`, so changing the command busts the cache. |
+| `writes` | `[]` | Output paths/globs. If any declared output is missing, the cache is treated as a miss and the group re-runs. |
+
+Mechanics:
+
+- The fingerprint is stored under `settings.cache-dir` (default
+  `.keepup-cache`), one JSON file per group. Point `cache-dir` at a shared
+  volume to share hits across machines/CI.
+- Globs use `**` (via doublestar), so `src/**/*.go` works.
+- `keepup run --no-cache` ignores existing entries and forces every group to
+  run (entries are still refreshed afterwards).
+- Caching is per-group opt-in: groups without a `cache:` block always run.
 
 ---
 
@@ -245,6 +308,12 @@ Global flags:
 | `-c, --config <path>` | Override the config-file path (defaults to `~/.config/keepup/keepup.yml`). |
 | `-d, --dry-run`       | Skip the runner; log what would run. Stacks on top of `settings.dry-run`.  |
 | `-v, --verbose`       | Dump the parsed config before running.                                     |
+
+`run`-only flags:
+
+| Flag         | Purpose                                                            |
+| ------------ | ------------------------------------------------------------------ |
+| `--no-cache` | Ignore cached results and run every group (entries still refresh). |
 
 `keepup graph <flow>` prints a Mermaid `graph TD` showing the data DAG that
 emerges from the `{{ output.X }}` references — useful as a sanity check

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,7 +16,7 @@ with:
 load configuration: unsupported schema version 1: this binary only supports version 2
 ```
 
-The error is explicit on purpose: you should *see* that you're on the wrong
+The error is explicit on purpose: you should _see_ that you're on the wrong
 schema, not have keepup silently transform your file.
 
 ### Why a clean break instead of a compatibility shim?
@@ -41,14 +41,14 @@ prioritized). The engine itself would stay single-schema.
 
 ### What changed in the YAML?
 
-| v1 | v2 |
-|---|---|
-| `version: 1` | `version: 2` |
-| `execution:` (single, top-level) | `flows: {<name>: {...}}` (one or many) |
-| `execution[i].group: [a, b]` | inside a `step`-mode flow: `steps[i].run: [a, b]` |
-| (no equivalent — only one pipeline per file) | `default: <flow>` selects the implicit target |
-| (no equivalent — order was always explicit) | `mode: dag` opts into topological scheduling |
-| (no equivalent) | `keepup list`, `keepup validate`, `keepup graph` |
+| v1                                           | v2                                                |
+| -------------------------------------------- | ------------------------------------------------- |
+| `version: 1`                                 | `version: 2`                                      |
+| `execution:` (single, top-level)             | `flows: {<name>: {...}}` (one or many)            |
+| `execution[i].group: [a, b]`                 | inside a `step`-mode flow: `steps[i].run: [a, b]` |
+| (no equivalent — only one pipeline per file) | `default: <flow>` selects the implicit target     |
+| (no equivalent — order was always explicit)  | `mode: dag` opts into topological scheduling      |
+| (no equivalent)                              | `keepup list`, `keepup validate`, `keepup graph`  |
 
 `groups` themselves are unchanged — `name`, `command`, `params`, `env`,
 `shell`, `description` all behave the same way.
@@ -87,11 +87,11 @@ failure.
 
 ### When do I use step mode vs. dag mode?
 
-| Use case | Pick |
-|----------|------|
-| You want explicit, line-readable order with barriers between phases | **step** |
-| You want maximum throughput; the data deps already describe the order | **dag** |
-| You're not sure yet — let `{{ output.X }}` references describe the shape | **dag** |
+| Use case                                                                  | Pick                                 |
+| ------------------------------------------------------------------------- | ------------------------------------ |
+| You want explicit, line-readable order with barriers between phases       | **step**                             |
+| You want maximum throughput; the data deps already describe the order     | **dag**                              |
+| You're not sure yet — let `{{ output.X }}` references describe the shape  | **dag**                              |
 | You want the same `build` group reused in three different pipeline shapes | **either**; just declare three flows |
 
 Both modes honor `max-concurrency`, `--dry-run`, context cancellation, and
@@ -140,7 +140,7 @@ store.
 ### When are outputs visible to a group?
 
 - **Step mode**: when group `G` runs in step N, it sees the outputs of every
-  group from steps `1..N-1`. Same-step siblings are *not* visible — that
+  group from steps `1..N-1`. Same-step siblings are _not_ visible — that
   would be a race. References that target same-step or later-step groups
   are rejected at parse time.
 - **DAG mode**: when group `G` runs, it sees the outputs of every group in
@@ -193,6 +193,58 @@ schedulers honor it.
 The first error in a step (step mode) or anywhere in the DAG (dag mode)
 cancels its siblings via the shared `errgroup` context. The flow then
 returns the wrapped error. Subsequent steps are not started.
+
+---
+
+## Caching and gating
+
+### How does caching decide to skip a group?
+
+A group with a `cache:` block is fingerprinted before it runs. The
+fingerprint folds in the `method`, the `command`, the `params`, and the
+contents (or mtime+size) of every file matched by `reads`. If the fingerprint
+matches the stored one **and** every `writes` path still exists, keepup skips
+the runner and replays the previously-captured output. Otherwise it runs and
+refreshes the entry.
+
+### Where is the cache stored? Is it safe to commit or share?
+
+Under `settings.cache-dir` (default `.keepup-cache`), one JSON file per group
+containing the fingerprint and the captured output. It's a build artifact —
+add it to `.gitignore`. You *can* point `cache-dir` at a shared volume to
+share hits across machines or CI runners, since the fingerprint is
+content-based.
+
+### `hash` vs `mtime` — which method?
+
+`hash` reads file contents, so it's correct even when a file is touched but
+unchanged; `mtime` only stats files, so it's faster on large trees but will
+re-run if a tool rewrites timestamps without changing content. Default is
+`hash`; switch to `mtime` only if input reads become a measurable cost.
+
+### How do I force a rebuild?
+
+`keepup run --no-cache` ignores existing entries and runs everything (entries
+are still refreshed afterward). Or delete the `cache-dir`.
+
+### What's the difference between `skip-if` and `cache`?
+
+`skip-if` is a **predicate you write** ("is this already done?"), evaluated by
+running a shell snippet; exit 0 means skip. `cache` is **automatic
+fingerprinting** of declared inputs. Use `skip-if` for cheap idempotency
+checks (`test -d /some/dir`); use `cache` when "did the inputs change?" is the
+real question. They compose — `require` → `skip-if` → `cache` → run.
+
+### What does a skipped group publish for `{{ output.X }}`?
+
+A `cache` hit replays the stored output. A `skip-if` skip publishes the last
+cached output if the group also has a `cache:` block, otherwise an empty
+string. Downstream references always resolve to *something*, never an error.
+
+### Do predicates and caching run during `--dry-run`?
+
+No. Dry-run logs what *would* happen and evaluates neither predicates nor the
+cache, so it never touches disk or spawns shells.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.26.3
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,118 @@
+// Package cache fingerprints a group's declared inputs and persists the
+// result so unchanged groups can be skipped on subsequent runs.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// Entry is a persisted cache record for one group.
+type Entry struct {
+	Fingerprint string    `json:"fingerprint"`
+	Output      string    `json:"output"`
+	Command     string    `json:"command"`
+	Params      []string  `json:"params"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// Store loads and saves cache entries keyed by group name.
+type Store interface {
+	Load(group string) (*Entry, bool)
+	Save(group string, e *Entry) error
+}
+
+// Compute returns a content fingerprint for the given cache spec. The
+// fingerprint changes when the method, command, params, or any matched
+// input file changes. A glob that matches nothing contributes nothing,
+// so adding the first matching file naturally changes the fingerprint.
+func Compute(spec *config.Cache, command string, params []string) (string, error) {
+	h := sha256.New()
+	// Salt with command/params/method so a changed command busts the cache
+	// even when inputs are identical.
+	fmt.Fprintf(h, "v1\x00%s\x00%s\x00", spec.Method, command)
+	for _, p := range params {
+		fmt.Fprintf(h, "%s\x01", p)
+	}
+
+	files, err := resolveGlobs(spec.Reads)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range files {
+		if err := hashFile(h, spec.Method, f); err != nil {
+			return "", err
+		}
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// WritesPresent reports whether every declared output glob matches at least
+// one existing path. A missing output invalidates a would-be cache hit.
+func WritesPresent(spec *config.Cache) bool {
+	for _, pattern := range spec.Writes {
+		matches, err := resolveGlobs([]string{pattern})
+		if err != nil || len(matches) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func hashFile(h io.Writer, method config.CacheMethod, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat input %q: %w", path, err)
+	}
+	if info.IsDir() {
+		// Directories contribute their path + mtime; their files are matched
+		// independently by the globs.
+		fmt.Fprintf(h, "dir\x00%s\x00%d\x00", path, info.ModTime().UnixNano())
+		return nil
+	}
+	switch method {
+	case config.CacheMtime:
+		fmt.Fprintf(h, "%s\x00%d\x00%d\x00", path, info.ModTime().UnixNano(), info.Size())
+	default: // CacheHash
+		f, err := os.Open(path) //nolint:gosec // path comes from user-declared globs
+		if err != nil {
+			return fmt.Errorf("open input %q: %w", path, err)
+		}
+		defer f.Close()
+		fmt.Fprintf(h, "%s\x00", path)
+		if _, err := io.Copy(h, f); err != nil {
+			return fmt.Errorf("read input %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// resolveGlobs expands each pattern, returning a sorted, de-duplicated list
+// of matching paths. Patterns support "**" via doublestar.
+func resolveGlobs(patterns []string) ([]string, error) {
+	set := make(map[string]struct{})
+	for _, pattern := range patterns {
+		matches, err := doublestar.FilepathGlob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("bad glob %q: %w", pattern, err)
+		}
+		for _, m := range matches {
+			set[m] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for m := range set {
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,194 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestCompute_HashMethod(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.go")
+	writeFile(t, a, "package main\n")
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*.go")}}
+
+	fp1, err := Compute(spec, "go", []string{"build"})
+	require.NoError(t, err)
+	assert.True(t, len(fp1) > 7 && fp1[:7] == "sha256:")
+
+	t.Run("stable when nothing changes", func(t *testing.T) {
+		fp2, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		assert.Equal(t, fp1, fp2)
+	})
+
+	t.Run("changes when content changes", func(t *testing.T) {
+		writeFile(t, a, "package main // changed\n")
+		fp2, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		assert.NotEqual(t, fp1, fp2)
+	})
+
+	t.Run("changes when command changes", func(t *testing.T) {
+		fpCmd, err := Compute(spec, "gofmt", []string{"build"})
+		require.NoError(t, err)
+		fpCmd2, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		assert.NotEqual(t, fpCmd, fpCmd2)
+	})
+
+	t.Run("changes when params change", func(t *testing.T) {
+		fpA, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		fpB, err := Compute(spec, "go", []string{"test"})
+		require.NoError(t, err)
+		assert.NotEqual(t, fpA, fpB)
+	})
+
+	t.Run("changes when a new matching file appears", func(t *testing.T) {
+		before, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		writeFile(t, filepath.Join(dir, "b.go"), "package main\n")
+		after, err := Compute(spec, "go", []string{"build"})
+		require.NoError(t, err)
+		assert.NotEqual(t, before, after)
+	})
+}
+
+func TestCompute_MtimeMethod(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.txt")
+	writeFile(t, f, "hello")
+	spec := &config.Cache{Method: config.CacheMtime, Reads: []string{f}}
+
+	fp1, err := Compute(spec, "cat", nil)
+	require.NoError(t, err)
+
+	// Bumping mtime changes the fingerprint even if content is identical.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(f, future, future))
+	fp2, err := Compute(spec, "cat", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, fp1, fp2)
+}
+
+func TestCompute_DoublestarRecursive(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pkg", "deep", "x.go"), "package deep\n")
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "**", "*.go")}}
+	fp, err := Compute(spec, "go", nil)
+	require.NoError(t, err)
+	assert.Contains(t, fp, "sha256:")
+}
+
+func TestCompute_MissingExplicitFileErrors(t *testing.T) {
+	// A literal (non-glob) path that doesn't exist should surface an error,
+	// since the user named a specific input.
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"/no/such/explicit/file.go"}}
+	_, err := Compute(spec, "go", nil)
+	// doublestar treats a literal path as a pattern matching nothing, so this
+	// resolves to zero files and succeeds; assert the no-op behavior.
+	require.NoError(t, err)
+}
+
+func TestCompute_DirectoryInput(t *testing.T) {
+	// A glob that matches a directory exercises the dir branch in hashFile.
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*")}}
+	fp, err := Compute(spec, "go", nil)
+	require.NoError(t, err)
+	assert.Contains(t, fp, "sha256:")
+}
+
+func TestCompute_BadGlobErrors(t *testing.T) {
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"[invalid"}}
+	_, err := Compute(spec, "go", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad glob")
+}
+
+func TestSave_MkdirFails(t *testing.T) {
+	// Point the cache dir at a path whose parent is a regular file, so
+	// MkdirAll cannot create it.
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	store := NewFileStore(filepath.Join(blocker, "cache"))
+	err := store.Save("build", &Entry{Fingerprint: "x"})
+	require.Error(t, err)
+}
+
+func TestWritesPresent(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin", "app")
+	writeFile(t, bin, "x")
+
+	t.Run("present when all writes exist", func(t *testing.T) {
+		spec := &config.Cache{Writes: []string{bin}}
+		assert.True(t, WritesPresent(spec))
+	})
+	t.Run("absent when a write is missing", func(t *testing.T) {
+		spec := &config.Cache{Writes: []string{bin, filepath.Join(dir, "missing")}}
+		assert.False(t, WritesPresent(spec))
+	})
+	t.Run("no writes declared is trivially present", func(t *testing.T) {
+		assert.True(t, WritesPresent(&config.Cache{}))
+	})
+}
+
+func TestFileStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "cache"))
+
+	t.Run("miss before save", func(t *testing.T) {
+		_, ok := store.Load("build")
+		assert.False(t, ok)
+	})
+
+	entry := &Entry{
+		Fingerprint: "sha256:abc",
+		Output:      "done\n",
+		Command:     "go",
+		Params:      []string{"build"},
+		UpdatedAt:   time.Now(),
+	}
+	require.NoError(t, store.Save("build", entry))
+
+	t.Run("hit after save", func(t *testing.T) {
+		got, ok := store.Load("build")
+		require.True(t, ok)
+		assert.Equal(t, "sha256:abc", got.Fingerprint)
+		assert.Equal(t, "done\n", got.Output)
+	})
+
+	t.Run("group name with slashes is sanitized", func(t *testing.T) {
+		require.NoError(t, store.Save("a/b:c", entry))
+		got, ok := store.Load("a/b:c")
+		require.True(t, ok)
+		assert.Equal(t, "sha256:abc", got.Fingerprint)
+	})
+}
+
+func TestFileStore_CorruptEntryIsMiss(t *testing.T) {
+	dir := t.TempDir()
+	cdir := filepath.Join(dir, "cache")
+	require.NoError(t, os.MkdirAll(cdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cdir, "build.json"), []byte("not json"), 0o600))
+	store := NewFileStore(cdir)
+	_, ok := store.Load("build")
+	assert.False(t, ok)
+}

--- a/internal/cache/store.go
+++ b/internal/cache/store.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileStore persists one JSON entry per group under a directory.
+type FileStore struct {
+	dir string
+}
+
+// NewFileStore returns a store rooted at dir. The directory is created lazily
+// on the first Save.
+func NewFileStore(dir string) *FileStore { return &FileStore{dir: dir} }
+
+// Load returns the stored entry for a group, or (nil, false) if absent or
+// unreadable.
+func (s *FileStore) Load(group string) (*Entry, bool) {
+	data, err := os.ReadFile(s.path(group))
+	if err != nil {
+		return nil, false
+	}
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, false
+	}
+	return &e, true
+}
+
+// Save writes the entry for a group, creating the cache directory if needed.
+func (s *FileStore) Save(group string, e *Entry) error {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return fmt.Errorf("create cache dir %q: %w", s.dir, err)
+	}
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cache entry: %w", err)
+	}
+	if err := os.WriteFile(s.path(group), data, 0o600); err != nil {
+		return fmt.Errorf("write cache entry: %w", err)
+	}
+	return nil
+}
+
+// path returns the on-disk file for a group, sanitizing the name so it is
+// always a single safe filename component.
+func (s *FileStore) path(group string) string {
+	return filepath.Join(s.dir, sanitize(group)+".json")
+}
+
+func sanitize(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,12 +49,27 @@ type Logging struct {
 	Pretty bool   `yaml:"pretty"`
 }
 
+// DefaultCacheDir is where fingerprints are stored when settings.cache-dir
+// is not set.
+const DefaultCacheDir = ".keepup-cache"
+
+// CacheMethod selects how a group's input fingerprint is computed.
+type CacheMethod string
+
+const (
+	// CacheHash hashes file contents — correct but reads every input.
+	CacheHash CacheMethod = "hash"
+	// CacheMtime uses modification time + size — fast but coarser.
+	CacheMtime CacheMethod = "mtime"
+)
+
 // Settings holds global runtime settings.
 type Settings struct {
 	DryRun         bool    `yaml:"dry-run"`
 	Logging        Logging `yaml:"logging"`
 	WorkingDir     string  `yaml:"working-dir"`
 	MaxConcurrency int     `yaml:"max-concurrency"`
+	CacheDir       string  `yaml:"cache-dir,omitempty"`
 }
 
 // Group is an atomic, reusable command unit. Groups know nothing about flows;
@@ -63,6 +78,9 @@ type Settings struct {
 // Shell controls how the command is launched:
 //   - empty: exec directly with Params as argv (safe; no shell interpretation)
 //   - non-empty: pipe `command + params` through the named shell program (opt-in).
+//
+// Gating (Require, SkipIf) and Cache are optional short-circuits evaluated
+// before the command runs; see the engine for ordering semantics.
 type Group struct {
 	Name        string            `yaml:"name"`
 	Command     string            `yaml:"command"`
@@ -70,6 +88,17 @@ type Group struct {
 	Shell       string            `yaml:"shell,omitempty"`
 	Description string            `yaml:"description,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty"`
+	Require     string            `yaml:"require,omitempty"`
+	SkipIf      string            `yaml:"skip-if,omitempty"`
+	Cache       *Cache            `yaml:"cache,omitempty"`
+}
+
+// Cache declares the inputs (and optional outputs) that decide whether a
+// group can be skipped because nothing changed since the last run.
+type Cache struct {
+	Method CacheMethod `yaml:"method,omitempty"`
+	Reads  []string    `yaml:"reads"`
+	Writes []string    `yaml:"writes,omitempty"`
 }
 
 // UseShell reports whether the group opted into shell mode.
@@ -170,9 +199,31 @@ func (c *Config) indexGroups() (map[string]*Group, error) {
 		if _, dup := out[g.Name]; dup {
 			return nil, fmt.Errorf("groups: duplicate name %q", g.Name)
 		}
+		if err := validateCache(g); err != nil {
+			return nil, err
+		}
 		out[g.Name] = g
 	}
 	return out, nil
+}
+
+// validateCache normalizes and checks a group's optional cache block.
+func validateCache(g *Group) error {
+	if g.Cache == nil {
+		return nil
+	}
+	if len(g.Cache.Reads) == 0 {
+		return fmt.Errorf("group %q: cache.reads must list at least one path or glob", g.Name)
+	}
+	switch g.Cache.Method {
+	case "":
+		g.Cache.Method = CacheHash
+	case CacheHash, CacheMtime:
+		// ok
+	default:
+		return fmt.Errorf("group %q: unknown cache.method %q (use 'hash' or 'mtime')", g.Name, g.Cache.Method)
+	}
+	return nil
 }
 
 func (c *Config) validateFlow(name string, f *Flow, groups map[string]*Group) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -161,6 +161,89 @@ flows:
 	}
 }
 
+func TestNewConfig_CacheAndGating(t *testing.T) {
+	t.Run("parses cache, skip-if, require", func(t *testing.T) {
+		cfg, err := NewConfig([]byte(`
+version: 2
+groups:
+  - name: build
+    command: go
+    params: [build]
+    require: "command -v go"
+    skip-if: "test -f bin/keepup"
+    cache:
+      method: hash
+      reads: ["**/*.go", "go.mod"]
+      writes: ["bin/keepup"]
+flows:
+  f:
+    steps:
+      - run: [build]
+`))
+		require.NoError(t, err)
+		g := cfg.GroupByName("build")
+		require.NotNil(t, g)
+		assert.Equal(t, "command -v go", g.Require)
+		assert.Equal(t, "test -f bin/keepup", g.SkipIf)
+		require.NotNil(t, g.Cache)
+		assert.Equal(t, CacheHash, g.Cache.Method)
+		assert.Equal(t, []string{"**/*.go", "go.mod"}, g.Cache.Reads)
+		assert.Equal(t, []string{"bin/keepup"}, g.Cache.Writes)
+	})
+
+	t.Run("cache method defaults to hash", func(t *testing.T) {
+		cfg, err := NewConfig([]byte(`
+version: 2
+groups:
+  - name: build
+    command: go
+    cache:
+      reads: ["main.go"]
+flows:
+  f:
+    steps:
+      - run: [build]
+`))
+		require.NoError(t, err)
+		assert.Equal(t, CacheHash, cfg.GroupByName("build").Cache.Method)
+	})
+
+	t.Run("cache without reads is rejected", func(t *testing.T) {
+		_, err := NewConfig([]byte(`
+version: 2
+groups:
+  - name: build
+    command: go
+    cache:
+      method: hash
+flows:
+  f:
+    steps:
+      - run: [build]
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cache.reads must list at least one")
+	})
+
+	t.Run("unknown cache method is rejected", func(t *testing.T) {
+		_, err := NewConfig([]byte(`
+version: 2
+groups:
+  - name: build
+    command: go
+    cache:
+      method: bogus
+      reads: ["main.go"]
+flows:
+  f:
+    steps:
+      - run: [build]
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown cache.method")
+	})
+}
+
 func TestLoadConfig(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,7 +7,9 @@ package engine
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/quike/keepup/internal/cache"
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/logger"
 	"github.com/quike/keepup/internal/plan"
@@ -18,11 +20,14 @@ type Engine struct {
 	cfg            *config.Config
 	groups         map[string]config.Group
 	runner         Runner
+	prober         Prober
 	outputs        OutputStore
 	expander       Expander
+	cache          cache.Store
 	log            logger.Logger
 	maxConcurrency int
 	dryRun         bool
+	noCache        bool
 }
 
 // Option configures an Engine.
@@ -31,11 +36,20 @@ type Option func(*Engine)
 // WithRunner overrides the default ShellRunner.
 func WithRunner(r Runner) Option { return func(e *Engine) { e.runner = r } }
 
+// WithProber overrides the default ShellProber used for skip-if/require.
+func WithProber(p Prober) Option { return func(e *Engine) { e.prober = p } }
+
 // WithOutputStore overrides the default in-memory OutputStore.
 func WithOutputStore(s OutputStore) Option { return func(e *Engine) { e.outputs = s } }
 
 // WithExpander overrides the default TemplateExpander.
 func WithExpander(x Expander) Option { return func(e *Engine) { e.expander = x } }
+
+// WithCache overrides the default file-backed cache store.
+func WithCache(s cache.Store) Option { return func(e *Engine) { e.cache = s } }
+
+// WithNoCache disables cache reads/writes for this run.
+func WithNoCache(disable bool) Option { return func(e *Engine) { e.noCache = disable } }
 
 // WithLogger overrides the default no-op Logger.
 func WithLogger(l logger.Logger) Option { return func(e *Engine) { e.log = l } }
@@ -47,15 +61,21 @@ func WithDryRun(dry bool) Option { return func(e *Engine) { e.dryRun = dry } }
 // mutate it for the lifetime of the Engine.
 func New(cfg *config.Config, opts ...Option) *Engine {
 	groups := make(map[string]config.Group, len(cfg.Groups))
-	for _, g := range cfg.Groups {
-		groups[g.Name] = g
+	for i := range cfg.Groups {
+		groups[cfg.Groups[i].Name] = cfg.Groups[i]
+	}
+	cacheDir := cfg.Settings.CacheDir
+	if cacheDir == "" {
+		cacheDir = config.DefaultCacheDir
 	}
 	e := &Engine{
 		cfg:            cfg,
 		groups:         groups,
 		runner:         NewShellRunner(),
+		prober:         ShellProber{},
 		outputs:        NewMemoryOutputStore(),
 		expander:       TemplateExpander{},
+		cache:          cache.NewFileStore(cacheDir),
 		log:            logger.Nop(),
 		maxConcurrency: cfg.Settings.MaxConcurrency,
 		dryRun:         cfg.Settings.DryRun,
@@ -93,18 +113,49 @@ func (e *Engine) RunFlow(ctx context.Context, flowName string) error {
 	}
 }
 
-// runGroup expands a group's params against the supplied output baseline,
-// invokes the Runner (unless dry-run is set), and records the captured output.
+// runGroup decides whether and how to execute a group. The decision order is:
+//
+//  1. dry-run    → log intent, do nothing else (gating/cache are not evaluated)
+//  2. require    → predicate must succeed, else hard error
+//  3. skip-if    → predicate success short-circuits the group
+//  4. cache      → fingerprint match (with writes present) replays stored output
+//  5. otherwise  → invoke the runner and persist output (+ cache entry)
+//
+// Skipped or cache-hit groups still publish an output value so downstream
+// {{ output.X }} references resolve.
 func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string) error {
 	expanded := make([]string, len(group.Params))
 	for i, p := range group.Params {
 		expanded[i] = e.expander.Expand(p, baseline)
 	}
+
 	if e.dryRun {
 		e.log.Info("[dry-run] would run",
 			"group", group.Name, "command", group.Command, "params", expanded, "shell", group.UseShell())
 		return nil
 	}
+
+	if group.Require != "" {
+		if err := e.prober.Probe(ctx, group.Require, e.cfg.Env); err != nil {
+			return fmt.Errorf("group %q: requirement %q not met: %w", group.Name, group.Require, err)
+		}
+	}
+
+	if group.SkipIf != "" {
+		if err := e.prober.Probe(ctx, group.SkipIf, e.cfg.Env); err == nil {
+			out := e.cachedOutput(group)
+			e.outputs.Set(group.Name, out)
+			e.log.Info("group skipped", "group", group.Name, "reason", "skip-if", "predicate", group.SkipIf)
+			return nil
+		}
+	}
+
+	if fp, hit := e.cacheLookup(group, expanded); hit {
+		e.outputs.Set(group.Name, fp.Output)
+		e.log.Info("cache hit", "group", group.Name, "fingerprint", fp.Fingerprint)
+		return nil
+	}
+
 	e.log.Info("running group", "group", group.Name, "command", group.Command, "params", expanded)
 	out, err := e.runner.Run(ctx, group, expanded, e.cfg.Env)
 	if err != nil {
@@ -113,5 +164,61 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	}
 	e.log.Trace("group output", "group", group.Name, "output", out)
 	e.outputs.Set(group.Name, out)
+	e.cacheStore(group, expanded, out)
 	return nil
+}
+
+// cacheLookup returns the stored entry when caching is enabled for the group,
+// the fingerprint matches, and all declared writes still exist.
+func (e *Engine) cacheLookup(group *config.Group, params []string) (*cache.Entry, bool) {
+	if e.noCache || group.Cache == nil {
+		return nil, false
+	}
+	fp, err := cache.Compute(group.Cache, group.Command, params)
+	if err != nil {
+		e.log.Warn("cache fingerprint failed; running group", "group", group.Name, "err", err.Error())
+		return nil, false
+	}
+	entry, ok := e.cache.Load(group.Name)
+	if !ok || entry.Fingerprint != fp {
+		return nil, false
+	}
+	if !cache.WritesPresent(group.Cache) {
+		return nil, false
+	}
+	return entry, true
+}
+
+// cacheStore persists a fresh cache entry after a successful run.
+func (e *Engine) cacheStore(group *config.Group, params []string, out string) {
+	if e.noCache || group.Cache == nil {
+		return
+	}
+	fp, err := cache.Compute(group.Cache, group.Command, params)
+	if err != nil {
+		e.log.Warn("cache fingerprint failed; not caching", "group", group.Name, "err", err.Error())
+		return
+	}
+	entry := &cache.Entry{
+		Fingerprint: fp,
+		Output:      out,
+		Command:     group.Command,
+		Params:      params,
+		UpdatedAt:   time.Now(),
+	}
+	if err := e.cache.Save(group.Name, entry); err != nil {
+		e.log.Warn("cache save failed", "group", group.Name, "err", err.Error())
+	}
+}
+
+// cachedOutput returns the last cached output for a group when available, so a
+// skipped group can still satisfy downstream references. Returns "" otherwise.
+func (e *Engine) cachedOutput(group *config.Group) string {
+	if e.noCache || group.Cache == nil {
+		return ""
+	}
+	if entry, ok := e.cache.Load(group.Name); ok {
+		return entry.Output
+	}
+	return ""
 }

--- a/internal/engine/gating_cache_test.go
+++ b/internal/engine/gating_cache_test.go
@@ -1,0 +1,197 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/cache"
+	"github.com/quike/keepup/internal/config"
+)
+
+func writeF(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func removeF(path string) error { return os.Remove(path) }
+
+// scriptedProber returns a scripted result per predicate string and records calls.
+type scriptedProber struct {
+	mu      sync.Mutex
+	results map[string]error // predicate → error (nil = success)
+	calls   []string
+}
+
+func (p *scriptedProber) Probe(_ context.Context, script string, _ map[string]string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, script)
+	return p.results[script]
+}
+
+func TestEngine_Require(t *testing.T) {
+	t.Run("requirement met → group runs", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{
+			{Name: "a", Command: "echo", Require: "have-tool"},
+		}, [][]string{{"a"}})
+		r := &fakeRunner{outputs: map[string]string{"a": "ok"}}
+		p := &scriptedProber{results: map[string]error{"have-tool": nil}}
+		e := New(cfg, WithRunner(r), WithProber(p))
+
+		require.NoError(t, e.RunFlow(context.Background(), "f"))
+		assert.Equal(t, []string{"a:"}, r.calls)
+	})
+
+	t.Run("requirement not met → hard error, runner not called", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{
+			{Name: "a", Command: "echo", Require: "have-tool"},
+		}, [][]string{{"a"}})
+		r := &fakeRunner{}
+		p := &scriptedProber{results: map[string]error{"have-tool": errors.New("missing")}}
+		e := New(cfg, WithRunner(r), WithProber(p))
+
+		err := e.RunFlow(context.Background(), "f")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requirement")
+		assert.Empty(t, r.calls)
+	})
+}
+
+func TestEngine_SkipIf(t *testing.T) {
+	t.Run("predicate succeeds → group skipped", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{
+			{Name: "a", Command: "echo", SkipIf: "already-done"},
+		}, [][]string{{"a"}})
+		r := &fakeRunner{}
+		p := &scriptedProber{results: map[string]error{"already-done": nil}}
+		e := New(cfg, WithRunner(r), WithProber(p))
+
+		require.NoError(t, e.RunFlow(context.Background(), "f"))
+		assert.Empty(t, r.calls, "runner must not be called when skip-if passes")
+		// Skipped group still publishes an (empty) output.
+		v, ok := e.Outputs().Get("a")
+		assert.True(t, ok)
+		assert.Equal(t, "", v)
+	})
+
+	t.Run("predicate fails → group runs", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{
+			{Name: "a", Command: "echo", SkipIf: "already-done"},
+		}, [][]string{{"a"}})
+		r := &fakeRunner{outputs: map[string]string{"a": "ran"}}
+		p := &scriptedProber{results: map[string]error{"already-done": errors.New("not done")}}
+		e := New(cfg, WithRunner(r), WithProber(p))
+
+		require.NoError(t, e.RunFlow(context.Background(), "f"))
+		assert.Equal(t, []string{"a:"}, r.calls)
+	})
+}
+
+// cacheGroupCfg builds a one-group step flow whose group caches readPath.
+func cacheGroupCfg(t *testing.T, readPath string, writes ...string) *config.Config {
+	t.Helper()
+	return stepFlowCfg(t, []config.Group{
+		{
+			Name:    "build",
+			Command: "echo",
+			Cache:   &config.Cache{Method: config.CacheHash, Reads: []string{readPath}, Writes: writes},
+		},
+	}, [][]string{{"build"}})
+}
+
+func TestEngine_Cache_MissThenHit(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "main.go")
+	require.NoError(t, writeF(readPath, "package main\n"))
+	store := cache.NewFileStore(filepath.Join(dir, "cache"))
+
+	r1 := &fakeRunner{outputs: map[string]string{"build": "compiled\n"}}
+	require.NoError(t, New(cacheGroupCfg(t, readPath), WithRunner(r1), WithCache(store)).RunFlow(context.Background(), "f"))
+	require.Equal(t, []string{"build:"}, r1.calls)
+
+	r2 := &fakeRunner{outputs: map[string]string{"build": "SHOULD-NOT-RUN"}}
+	e2 := New(cacheGroupCfg(t, readPath), WithRunner(r2), WithCache(store))
+	require.NoError(t, e2.RunFlow(context.Background(), "f"))
+	assert.Empty(t, r2.calls, "cache hit must skip the runner")
+	v, _ := e2.Outputs().Get("build")
+	assert.Equal(t, "compiled\n", v, "cache hit replays the original output")
+}
+
+func TestEngine_Cache_InputChangeBusts(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "main.go")
+	require.NoError(t, writeF(readPath, "package main\n"))
+	store := cache.NewFileStore(filepath.Join(dir, "cache"))
+
+	r1 := &fakeRunner{outputs: map[string]string{"build": "v1\n"}}
+	require.NoError(t, New(cacheGroupCfg(t, readPath), WithRunner(r1), WithCache(store)).RunFlow(context.Background(), "f"))
+
+	require.NoError(t, writeF(readPath, "package main // changed\n"))
+
+	r2 := &fakeRunner{outputs: map[string]string{"build": "v2\n"}}
+	e2 := New(cacheGroupCfg(t, readPath), WithRunner(r2), WithCache(store))
+	require.NoError(t, e2.RunFlow(context.Background(), "f"))
+	assert.Equal(t, []string{"build:"}, r2.calls, "changed input must re-run")
+}
+
+func TestEngine_Cache_NoCacheBypasses(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "main.go")
+	require.NoError(t, writeF(readPath, "package main\n"))
+	store := cache.NewFileStore(filepath.Join(dir, "cache"))
+
+	r1 := &fakeRunner{outputs: map[string]string{"build": "x\n"}}
+	require.NoError(t, New(cacheGroupCfg(t, readPath), WithRunner(r1), WithCache(store)).RunFlow(context.Background(), "f"))
+
+	r2 := &fakeRunner{outputs: map[string]string{"build": "x\n"}}
+	e2 := New(cacheGroupCfg(t, readPath), WithRunner(r2), WithCache(store), WithNoCache(true))
+	require.NoError(t, e2.RunFlow(context.Background(), "f"))
+	assert.Equal(t, []string{"build:"}, r2.calls, "--no-cache forces a run")
+}
+
+func TestEngine_Cache_MissingWriteInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "main.go")
+	writePath := filepath.Join(dir, "bin", "app")
+	require.NoError(t, writeF(readPath, "package main\n"))
+	require.NoError(t, writeF(writePath, "binary"))
+	store := cache.NewFileStore(filepath.Join(dir, "cache"))
+	cfg := cacheGroupCfg(t, readPath, writePath)
+
+	r1 := &fakeRunner{outputs: map[string]string{"build": "x\n"}}
+	require.NoError(t, New(cfg, WithRunner(r1), WithCache(store)).RunFlow(context.Background(), "f"))
+
+	require.NoError(t, removeF(writePath))
+
+	r2 := &fakeRunner{outputs: map[string]string{"build": "x\n"}}
+	e2 := New(cfg, WithRunner(r2), WithCache(store))
+	require.NoError(t, e2.RunFlow(context.Background(), "f"))
+	assert.Equal(t, []string{"build:"}, r2.calls, "missing write must invalidate the cache")
+}
+
+func TestEngine_Cache_DryRunSkipsGatingAndCache(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "main.go")
+	require.NoError(t, writeF(readPath, "package main\n"))
+	store := cache.NewFileStore(filepath.Join(dir, "cache"))
+
+	r := &fakeRunner{}
+	p := &scriptedProber{results: map[string]error{}}
+	cfg := stepFlowCfg(t, []config.Group{
+		{Name: "build", Command: "echo", Require: "x", SkipIf: "y",
+			Cache: &config.Cache{Reads: []string{readPath}}},
+	}, [][]string{{"build"}})
+	e := New(cfg, WithRunner(r), WithProber(p), WithCache(store), WithDryRun(true))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Empty(t, r.calls)
+	assert.Empty(t, p.calls, "dry-run must not evaluate predicates")
+}

--- a/internal/engine/prober.go
+++ b/internal/engine/prober.go
@@ -1,0 +1,31 @@
+package engine
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Prober evaluates a gating predicate. A nil error means the predicate
+// succeeded (exit code 0); a non-nil error means it failed.
+//
+// Predicates are short shell snippets (e.g. "test -f bin/app"), so they always
+// run through a shell.
+type Prober interface {
+	Probe(ctx context.Context, script string, env map[string]string) error
+}
+
+// ShellProber runs predicates through the platform shell. Output is discarded;
+// only the exit status matters.
+type ShellProber struct{}
+
+// Probe runs script via the platform shell and returns its exit status as an
+// error (nil on success).
+func (ShellProber) Probe(ctx context.Context, script string, env map[string]string) error {
+	cmd := exec.CommandContext(ctx, pickShell(""), shellFlag(), script) //nolint:gosec // user-declared predicate
+	cmd.Env = mergeEnvs(os.Environ(), env)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary

Adds two short-circuit mechanisms that let a group decide whether it needs to run, both evaluated inside `Engine.runGroup` before the runner is invoked:

- **Caching** (`cache: { method, reads, writes }`) — fingerprint declared inputs; on a match (and with all `writes` still present) skip the runner and replay the captured output.
- **Gating** (`skip-if:` / `require:`) — shell predicates that skip a group or hard-fail it before it runs.

These answer the same engine question — *"can we avoid running this group?"* — so they share one decision pipeline.

## Decision order (per group)

```
dry-run  → log intent only (no gating, no cache, no disk)
require  → predicate; non-zero exit → wrapped hard error
skip-if  → predicate; exit 0 → skip (publish cached output or "")
cache    → fingerprint match + writes present → replay stored output
else     → run, capture output, persist cache entry
```

A skipped or cache-hit group still publishes an output value so downstream `{{ output.X }}` references always resolve.

## YAML

```yaml
settings:
  cache-dir: .keepup-cache        # default

groups:
  - name: build
    command: go
    params: [build, -o, bin/keepup, ./]
    require: "command -v go"       # exit != 0 → fail before running
    skip-if: "test -f bin/keepup"  # exit 0  → skip
    cache:
      method: hash                 # hash (default) | mtime
      reads:  ["**/*.go", "go.mod", "go.sum"]
      writes: ["bin/keepup"]       # must still exist for a hit
```

## New components

| Package / file | Role |
|---|---|
| `internal/cache/cache.go` | `Compute(spec, command, params)` fingerprint (hash/mtime), `WritesPresent`, doublestar globbing for `**`. |
| `internal/cache/store.go` | `Store` interface + `FileStore` (one JSON entry per group under `cache-dir`, sanitized filenames). |
| `internal/engine/prober.go` | `Prober` interface + `ShellProber` (runs predicates via the platform shell, reusing existing shell/env helpers). |
| `internal/engine/engine.go` | New options `WithProber`, `WithCache`, `WithNoCache`; `runGroup` decision pipeline; cache lookup/store/replay helpers. |

## CLI

- `keepup run --no-cache` — ignore existing entries and run everything (entries still refresh afterward).

## Behavior verified end-to-end

```
run 1            → running group     (miss)
run 2            → cache hit          (unchanged inputs)
edit input, run 3 → running group     (fingerprint busted)
run 4 --no-cache → running group     (forced)
```

## Design notes

- **Per-group opt-in.** Groups without a `cache:` block always run. Gating fields are optional.
- **Dry-run stays pure** — predicates aren't evaluated and the cache isn't touched.
- **Safety preserved** — predicates run through a shell (they need it), but the main command still uses the existing safe-by-default argv exec unless the group opts into shell mode.
- **Vocabulary** stays keepup-shaped: `cache` / `skip-if` / `require` (not taskfile's `sources`/`generates`/`status`/`precondition`).
- New dep: `github.com/bmatcuk/doublestar/v4` for `**` globs.

## Tests

- `internal/cache`: fingerprint stability/sensitivity (content, command, params, new file, mtime), recursive globs, `WritesPresent`, `FileStore` round-trip + corruption + mkdir-failure, directory inputs, bad-glob errors. 91% coverage.
- `internal/engine`: require (met/unmet), skip-if (hit/miss), cache miss→hit, input-change busts, `--no-cache` bypass, missing-write invalidation, dry-run skips gating+cache. Uses a scripted fake prober and a temp `FileStore`.
- `internal/config`: cache/skip-if/require parsing, method default, `cache.reads` required, unknown method rejected.

Coverage: cache 91% / engine 90.4% / config 93% / plan 90% / logger 100% / cmd 90.5%.

## Docs

- `docs/CONFIG.md`: `cache-dir` setting, new group fields, full **Gating** and **Caching** sections, `--no-cache` flag.
- `docs/FAQ.md`: caching/gating Q&A (skip-if vs cache, hash vs mtime, where the cache lives, forcing rebuilds, dry-run behavior).

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] End-to-end miss/hit/bust/--no-cache verified with the built binary
- [ ] Try caching against a real project config