### PR TITLE
feat: keepup watch — incremental re-runs on file change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,20 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: make build
+      - name: Release outputs
+        run: |
+          echo "release-published: ${{ needs.release.outputs.release-published }}"
+          echo "release-version:   ${{ needs.release.outputs.release-version }}"
+          echo "release-major:     ${{ needs.release.outputs.release-major }}"
+          echo "release-minor:     ${{ needs.release.outputs.release-minor }}"
+          echo "release-patch:     ${{ needs.release.outputs.release-patch }}"
+          echo "release-type:      ${{ needs.release.outputs.release-type }}"
+          echo "release-git-head:  ${{ needs.release.outputs.release-git-head }}"
+          echo "release-git-tag:   ${{ needs.release.outputs.release-git-tag }}"
+      - name: Build
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.release-version }}
+        run: make build VERSION="${RELEASE_VERSION:-0.0.0}"
       - uses: codecov/codecov-action@v6
         with:
           files: target/coverage.out

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "Verbose output")
 
 	root.AddCommand(newRunCmd(opts))
+	root.AddCommand(newWatchCmd(opts, stdout))
 	root.AddCommand(newListCmd(opts, stdout))
 	root.AddCommand(newValidateCmd(opts, stdout))
 	root.AddCommand(newGraphCmd(opts, stdout))

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/engine"
+	"github.com/quike/keepup/internal/watch"
+)
+
+func newWatchCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "watch [flow]",
+		Short: "Re-run a flow whenever its groups' cache.reads inputs change",
+		Long: "Watch the files declared in the cache.reads of the flow's groups and " +
+			"re-run the flow on every change. Caching makes unaffected groups no-ops, " +
+			"so only the work that actually depends on a changed file re-executes.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.load(cmd.OutOrStdout()); err != nil {
+				return err
+			}
+			flowName := opts.cfg.Default
+			if len(args) == 1 {
+				flowName = args[0]
+			}
+			if flowName == "" {
+				return fmt.Errorf("no flow specified and no default declared")
+			}
+			flow, ok := opts.cfg.Flows[flowName]
+			if !ok {
+				return fmt.Errorf("flow %q not found", flowName)
+			}
+
+			patterns := watchPatterns(opts.cfg, &flow)
+			if len(patterns) == 0 {
+				return fmt.Errorf(
+					"flow %q has no watchable inputs: add a cache.reads block to at least one of its groups",
+					flowName,
+				)
+			}
+
+			src, err := watch.NewFSNotifySource()
+			if err != nil {
+				return fmt.Errorf("create file watcher: %w", err)
+			}
+			defer func() { _ = src.Close() }()
+
+			dirs, err := watch.ResolveWatchDirs(patterns)
+			if err != nil {
+				return fmt.Errorf("resolve watch dirs: %w", err)
+			}
+			for _, d := range dirs {
+				if err := src.Add(d); err != nil {
+					return fmt.Errorf("watch %q: %w", d, err)
+				}
+			}
+
+			fmt.Fprintf(stdout, "watching %d dir(s) for flow %q; press Ctrl-C to stop\n", len(dirs), flowName)
+
+			w := watch.New(patterns, src, watch.WithLogger(opts.log))
+			return w.Run(cmd.Context(), func(ctx context.Context) error {
+				e := engine.New(opts.cfg,
+					engine.WithLogger(opts.log),
+					engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),
+				)
+				return e.RunFlow(ctx, flowName)
+			})
+		},
+	}
+}
+
+// watchPatterns collects the de-duplicated cache.reads globs across every group
+// in the flow. These are the inputs worth watching.
+func watchPatterns(cfg *config.Config, flow *config.Flow) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, member := range flow.Members() {
+		g := cfg.GroupByName(member)
+		if g == nil || g.Cache == nil {
+			continue
+		}
+		for _, r := range g.Cache.Reads {
+			if _, dup := seen[r]; dup {
+				continue
+			}
+			seen[r] = struct{}{}
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+func TestWatchPatterns(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Groups: []config.Group{
+			{Name: "build", Command: "go", Cache: &config.Cache{Reads: []string{"**/*.go", "go.mod"}}},
+			{Name: "test", Command: "go", Cache: &config.Cache{Reads: []string{"**/*.go"}}}, // dup read
+			{Name: "lint", Command: "golangci-lint"},                                        // no cache
+		},
+	}
+	flow := &config.Flow{Mode: config.ModeStep, Steps: []config.Step{{Run: []string{"build", "test", "lint"}}}}
+
+	got := watchPatterns(cfg, flow)
+	// Deduped, declaration order preserved.
+	assert.Equal(t, []string{"**/*.go", "go.mod"}, got)
+}
+
+func TestWatchPatterns_NoneWhenNoCache(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Groups: []config.Group{{Name: "a", Command: "echo"}},
+	}
+	flow := &config.Flow{Mode: config.ModeStep, Steps: []config.Step{{Run: []string{"a"}}}}
+	assert.Empty(t, watchPatterns(cfg, flow))
+}
+
+func TestWatchCmd_ErrorsWithoutCacheReads(t *testing.T) {
+	t.Parallel()
+	// A valid flow whose groups declare no cache.reads → watch has nothing to do.
+	cfg := `
+version: 2
+groups:
+  - name: a
+    command: echo
+default: f
+flows:
+  f:
+    mode: step
+    steps:
+      - run: [a]
+`
+	cfgPath := writeTempConfig(t, cfg)
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"watch", "f", "--config", cfgPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no watchable inputs")
+}
+
+func TestWatchCmd_ErrorsOnUnknownFlow(t *testing.T) {
+	t.Parallel()
+	cfg := `
+version: 2
+groups:
+  - name: a
+    command: echo
+    cache:
+      reads: ["*.go"]
+flows:
+  f:
+    steps:
+      - run: [a]
+`
+	cfgPath := writeTempConfig(t, cfg)
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"watch", "ghost", "--config", cfgPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -2,12 +2,17 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/watch"
 )
 
 func TestWatchPatterns(t *testing.T) {
@@ -57,6 +62,62 @@ flows:
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no watchable inputs")
+}
+
+// stubSource is a minimal watch.Source driven by the test.
+type stubSource struct {
+	events chan watch.Event
+	errs   chan error
+	mu     sync.Mutex
+	added  []string
+}
+
+func newStubSource() *stubSource {
+	return &stubSource{events: make(chan watch.Event, 8), errs: make(chan error, 1)}
+}
+
+func (s *stubSource) Events() <-chan watch.Event { return s.events }
+func (s *stubSource) Errors() <-chan error       { return s.errs }
+func (s *stubSource) Add(p string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.added = append(s.added, p)
+	return nil
+}
+func (s *stubSource) Close() error { return nil }
+
+// TestWatch_FixtureDrivesRerun loads the watch test-resource, derives the watch
+// set from its cache.reads, and verifies that a change matching one of those
+// globs triggers a re-run through the real watch.Watcher.
+func TestWatch_FixtureDrivesRerun(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../internal/config/test-resources/config-watch.yml")
+	require.NoError(t, err)
+	flow := cfg.Flows["dev"]
+
+	patterns := watchPatterns(cfg, &flow)
+	// The dev flow's groups declare these reads (deduped, in order).
+	assert.Equal(t, []string{"proto/**/*.proto", "**/*.go", "go.mod", "go.sum"}, patterns)
+
+	src := newStubSource()
+	w := watch.New(patterns, src, watch.WithDebounce(10*time.Millisecond), watch.WithInitialRun(false))
+
+	var runs int32
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		_ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
+
+	// A change to a Go file matches "**/*.go" → should trigger one re-run.
+	src.events <- watch.Event{Path: "internal/app/main.go"}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 },
+		time.Second, 5*time.Millisecond)
+
+	// A non-matching change (Markdown) must NOT trigger another run.
+	src.events <- watch.Event{Path: "README.md"}
+	time.Sleep(40 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&runs))
 }
 
 func TestWatchCmd_ErrorsOnUnknownFlow(t *testing.T) {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -294,12 +294,19 @@ at an existing flow; otherwise the file is rejected at parse time.
 
 ```sh
 keepup run [flow]            # run the named flow, or the default
+keepup watch [flow]          # re-run a flow when its cache.reads inputs change
 keepup list                  # show declared flows + descriptions
 keepup list groups           # show declared groups
 keepup validate              # parse + validate; no execution
 keepup graph [flow]          # emit a Mermaid diagram of the data DAG
 keepup version
 ```
+
+`keepup watch` watches the union of `cache.reads` globs across the chosen
+flow's groups, re-running the flow on any change. Because caching short-circuits
+unchanged groups, only the work that actually depends on a changed file
+re-executes. The flow must have at least one group with a `cache.reads` block,
+otherwise there is nothing to watch.
 
 Global flags:
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -248,6 +248,47 @@ cache, so it never touches disk or spawns shells.
 
 ---
 
+## Watch mode
+
+### What does `keepup watch` watch?
+
+The union of the `cache.reads` globs across the chosen flow's groups. Those
+declarations already describe each group's inputs, so watch reuses them as the
+file set — no separate watch configuration. The flow must have at least one
+group with `cache.reads`, otherwise there's nothing to watch and the command
+errors.
+
+### Why does watch reuse `cache.reads` instead of a dedicated `watch:` field?
+
+Because the inputs that should trigger a rebuild are exactly the inputs that
+define a cache hit. Reusing one declaration keeps the two features consistent:
+the same change that busts the cache is the same change that triggers a re-run,
+and unchanged groups are skipped on each pass.
+
+### How does it avoid rebuilding everything on every keystroke?
+
+Two layers. First, a short debounce (200ms) collapses bursts of editor events
+into one re-run. Second, caching means the re-run only executes groups whose
+inputs actually changed — the rest are cache hits.
+
+### Does watch run once on start?
+
+Yes. It performs an initial run immediately, then watches. A failing run is
+logged but does not stop watching — fix the code and save again.
+
+### How do I stop it?
+
+Ctrl-C (SIGINT) or SIGTERM. The signal propagates through the context, the
+in-flight run is cancelled, and `watch` returns cleanly.
+
+### Are newly-created files/directories picked up?
+
+New directories under a watched tree are added automatically as they appear, so
+files created in them are seen. Brand-new top-level trees that didn't exist when
+watch started are the one gap — restart watch if you add a whole new source root.
+
+---
+
 ## CLI
 
 ### What replaces the old `--group <name>` flag?

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -53,6 +53,7 @@ flows:
 ```sh
 keepup run                # run the default flow
 keepup run <flow>         # run a specific flow
+keepup watch [flow]       # re-run a flow when its cache.reads inputs change
 keepup list               # list flows (default starred)
 keepup list groups        # list groups
 keepup validate           # parse & reference-check; no execution
@@ -65,6 +66,33 @@ Common flags:
 - `-c, --config <path>` — point at a config file
 - `-d, --dry-run` — log what would run; never invoke the runner
 - `-v, --verbose` — dump the parsed config before running
+- `--no-cache` (run only) — ignore cached results and run every group
+
+## Watch mode
+
+`keepup watch` turns the inner loop into a live one. It watches the files
+declared in the `cache.reads` of the flow's groups and re-runs the flow on
+each change; caching ensures only the affected groups actually execute.
+
+```yaml
+groups:
+  - name: build
+    command: go
+    params: [build, ./...]
+    cache:
+      reads: ["**/*.go", "go.mod"]
+flows:
+  dev:
+    steps:
+      - run: [build]
+```
+
+```sh
+keepup watch dev   # build now, then rebuild on every .go change; Ctrl-C to stop
+```
+
+The flow needs at least one group with a `cache.reads` block — that's the
+watch set.
 
 ## Multiple flows over the same groups
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.3
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -265,6 +265,33 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, ModeDAG, cfg.Flows["pipeline-dag"].Mode)
 	})
 
+	t.Run("watch/cache resource file parses", func(t *testing.T) {
+		cfg, err := LoadConfig("./test-resources/config-watch.yml")
+		require.NoError(t, err)
+		assert.Equal(t, ".keepup-cache", cfg.Settings.CacheDir)
+		require.Len(t, cfg.Groups, 3)
+
+		gen := cfg.GroupByName("generate")
+		require.NotNil(t, gen)
+		require.NotNil(t, gen.Cache)
+		assert.Equal(t, CacheHash, gen.Cache.Method)
+		assert.Equal(t, []string{"proto/**/*.proto"}, gen.Cache.Reads)
+		assert.Equal(t, []string{"internal/pb/**/*.go"}, gen.Cache.Writes)
+
+		build := cfg.GroupByName("build")
+		require.NotNil(t, build)
+		assert.Equal(t, "command -v echo", build.Require)
+
+		test := cfg.GroupByName("test")
+		require.NotNil(t, test)
+		assert.Equal(t, "false", test.SkipIf)
+		assert.Equal(t, CacheMtime, test.Cache.Method)
+
+		require.Contains(t, cfg.Flows, "dev")
+		require.Contains(t, cfg.Flows, "dev-dag")
+		assert.Equal(t, "dev", cfg.Default)
+	})
+
 	t.Run("file not found", func(t *testing.T) {
 		_, err := LoadConfig("nonexistent.yaml")
 		require.Error(t, err)

--- a/internal/config/test-resources/config-watch.yml
+++ b/internal/config/test-resources/config-watch.yml
@@ -1,0 +1,57 @@
+---
+# A watch/cache-oriented config used by tests to exercise `keepup watch` and
+# per-group caching against a realistic shape: groups declare cache.reads so
+# the watch set can be derived, and one group references another's output.
+version: 2
+
+settings:
+  logging:
+    level: info
+    pretty: true
+  cache-dir: .keepup-cache
+  max-concurrency: 4
+
+groups:
+  - name: generate
+    description: "Code generation step"
+    command: echo
+    params: ["generated"]
+    cache:
+      method: hash
+      reads: ["proto/**/*.proto"]
+      writes: ["internal/pb/**/*.go"]
+
+  - name: build
+    description: "Compile the binary"
+    command: echo
+    params: ["built {{ output.generate }}"]
+    require: "command -v echo"
+    cache:
+      method: hash
+      reads: ["**/*.go", "go.mod", "go.sum"]
+      writes: ["bin/app"]
+
+  - name: test
+    description: "Run the test suite"
+    command: echo
+    params: ["tested"]
+    skip-if: "false"
+    cache:
+      method: mtime
+      reads: ["**/*.go"]
+
+default: dev
+
+flows:
+  dev:
+    description: "Generate → build → test, step mode (watch target)"
+    mode: step
+    steps:
+      - run: [generate]
+      - run: [build]
+      - run: [test]
+
+  dev-dag:
+    description: "Same groups scheduled by data deps"
+    mode: dag
+    run: [generate, build, test]

--- a/internal/watch/fsnotify_source.go
+++ b/internal/watch/fsnotify_source.go
@@ -1,0 +1,54 @@
+package watch
+
+import (
+	"github.com/fsnotify/fsnotify"
+)
+
+// fsnotifySource adapts fsnotify to the Source interface.
+type fsnotifySource struct {
+	w      *fsnotify.Watcher
+	events chan Event
+	errs   chan error
+}
+
+// NewFSNotifySource returns a Source backed by fsnotify. Call Add for each
+// directory to watch; Close releases the underlying watcher.
+func NewFSNotifySource() (Source, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	s := &fsnotifySource{
+		w:      w,
+		events: make(chan Event),
+		errs:   make(chan error, 1),
+	}
+	go s.pump()
+	return s, nil
+}
+
+func (s *fsnotifySource) pump() {
+	for {
+		select {
+		case ev, ok := <-s.w.Events:
+			if !ok {
+				close(s.events)
+				return
+			}
+			s.events <- Event{Path: ev.Name}
+		case err, ok := <-s.w.Errors:
+			if !ok {
+				return
+			}
+			select {
+			case s.errs <- err:
+			default:
+			}
+		}
+	}
+}
+
+func (s *fsnotifySource) Events() <-chan Event  { return s.events }
+func (s *fsnotifySource) Errors() <-chan error  { return s.errs }
+func (s *fsnotifySource) Add(path string) error { return s.w.Add(path) }
+func (s *fsnotifySource) Close() error          { return s.w.Close() }

--- a/internal/watch/fsnotify_source_test.go
+++ b/internal/watch/fsnotify_source_test.go
@@ -1,0 +1,48 @@
+package watch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFSNotifySource_RealFileChange exercises the production fsnotify source
+// end-to-end: a real write under a watched directory must drive a re-run.
+// Uses generous timeouts to stay robust across platforms.
+func TestFSNotifySource_RealFileChange(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.go")
+	require.NoError(t, os.WriteFile(target, []byte("package main\n"), 0o600))
+
+	src, err := NewFSNotifySource()
+	require.NoError(t, err)
+	defer func() { _ = src.Close() }()
+	require.NoError(t, src.Add(dir))
+
+	var runs int32
+	w := New([]string{filepath.Join(dir, "*.go")}, src,
+		WithDebounce(30*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+
+	// Give the watcher a moment to settle, then modify the file.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, os.WriteFile(target, []byte("package main // edit\n"), 0o600))
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) >= 1 },
+		3*time.Second, 20*time.Millisecond, "expected a re-run after a real file change")
+}
+
+func TestFSNotifySource_AddMissingDirErrors(t *testing.T) {
+	src, err := NewFSNotifySource()
+	require.NoError(t, err)
+	defer func() { _ = src.Close() }()
+	require.Error(t, src.Add(filepath.Join(t.TempDir(), "does-not-exist")))
+}

--- a/internal/watch/match.go
+++ b/internal/watch/match.go
@@ -1,0 +1,106 @@
+// Package watch re-runs a callback when files matching a set of globs change.
+//
+// The matching and directory-resolution helpers are pure and unit-tested; the
+// event loop consumes an injectable Source so it can be exercised without real
+// filesystem timing.
+package watch
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// Matches reports whether path satisfies any of the glob patterns. Patterns
+// support "**" via doublestar and are matched with OS path separators.
+func Matches(patterns []string, path string) bool {
+	clean := filepath.Clean(path)
+	for _, p := range patterns {
+		if ok, err := doublestar.PathMatch(filepath.Clean(p), clean); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// globBase returns the longest leading path segment of a pattern that contains
+// no glob metacharacters — the directory from which a recursive watch should
+// start. For "src/**/*.go" it returns "src"; for "*.go" it returns ".". Absolute
+// patterns keep their leading separator. A wholly-literal pattern resolves to
+// its containing directory.
+func globBase(pattern string) string {
+	cleaned := filepath.Clean(pattern)
+	sep := string(filepath.Separator)
+	abs := strings.HasPrefix(cleaned, sep)
+
+	parts := strings.Split(strings.TrimPrefix(cleaned, sep), sep)
+	base := make([]string, 0, len(parts))
+	hasGlob := false
+	for _, part := range parts {
+		if strings.ContainsAny(part, "*?[{") {
+			hasGlob = true
+			break
+		}
+		base = append(base, part)
+	}
+
+	joined := strings.Join(base, sep)
+	if abs {
+		joined = filepath.Clean(sep + joined)
+	} else if joined == "" {
+		joined = "."
+	}
+
+	if !hasGlob {
+		// Wholly-literal pattern → watch its directory.
+		return dirOf(joined)
+	}
+	if joined == "" {
+		return "."
+	}
+	return joined
+}
+
+func dirOf(p string) string {
+	d := filepath.Dir(p)
+	if d == "" {
+		return "."
+	}
+	return d
+}
+
+// ResolveWatchDirs returns the de-duplicated, sorted set of directories that
+// must be watched so every file matched by patterns is observed. Each glob's
+// base directory is walked recursively (to cover "**"). Missing bases are
+// skipped rather than erroring — they may be created later.
+func ResolveWatchDirs(patterns []string) ([]string, error) {
+	set := map[string]struct{}{}
+	for _, p := range patterns {
+		base := globBase(p)
+		err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// A non-existent base is fine; stop walking this branch.
+				if path == base {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() {
+				set[path] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	out := make([]string, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/watch/match_test.go
+++ b/internal/watch/match_test.go
@@ -1,0 +1,82 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		want     bool
+	}{
+		{"exact file", []string{"go.mod"}, "go.mod", true},
+		{"single-level glob", []string{"*.go"}, "main.go", true},
+		{"single-level glob no match in subdir", []string{"*.go"}, "sub/main.go", false},
+		{"doublestar recursive", []string{"src/**/*.go"}, "src/a/b/c.go", true},
+		{"doublestar at root", []string{"**/*.go"}, "deep/nested/x.go", true},
+		{"no match", []string{"*.go"}, "README.md", false},
+		{"one of several", []string{"*.md", "*.go"}, "main.go", true},
+		{"dot-cleaned path", []string{"src/*.go"}, "./src/a.go", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, Matches(tc.patterns, tc.path))
+		})
+	}
+}
+
+func TestGlobBase(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"src/**/*.go": "src",
+		"*.go":        ".",
+		"go.mod":      ".",
+		"a/b/c.txt":   "a/b",
+		"a/b/*.txt":   "a/b",
+		"**/*.go":     ".",
+	}
+	for pattern, want := range tests {
+		assert.Equal(t, want, globBase(pattern), "pattern=%q", pattern)
+	}
+}
+
+func TestResolveWatchDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Build: root/src/a, root/src/a/deep, root/other
+	mk := func(parts ...string) {
+		p := filepath.Join(append([]string{root}, parts...)...)
+		require.NoError(t, os.MkdirAll(p, 0o755))
+	}
+	mk("src", "a", "deep")
+	mk("other")
+
+	t.Run("recursive walk of glob base", func(t *testing.T) {
+		dirs, err := ResolveWatchDirs([]string{filepath.Join(root, "src", "**", "*.go")})
+		require.NoError(t, err)
+		assert.Contains(t, dirs, filepath.Join(root, "src"))
+		assert.Contains(t, dirs, filepath.Join(root, "src", "a"))
+		assert.Contains(t, dirs, filepath.Join(root, "src", "a", "deep"))
+		assert.NotContains(t, dirs, filepath.Join(root, "other"))
+	})
+
+	t.Run("missing base is skipped, not an error", func(t *testing.T) {
+		dirs, err := ResolveWatchDirs([]string{filepath.Join(root, "does-not-exist", "*.go")})
+		require.NoError(t, err)
+		assert.Empty(t, dirs)
+	})
+
+	t.Run("literal file watches its directory", func(t *testing.T) {
+		dirs, err := ResolveWatchDirs([]string{filepath.Join(root, "src", "go.mod")})
+		require.NoError(t, err)
+		assert.Contains(t, dirs, filepath.Join(root, "src"))
+	})
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,110 @@
+package watch
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/quike/keepup/internal/logger"
+)
+
+// DefaultDebounce coalesces bursts of filesystem events (editors often emit
+// several per save) into a single re-run.
+const DefaultDebounce = 200 * time.Millisecond
+
+// Event is a filesystem change notification carrying the affected path.
+type Event struct{ Path string }
+
+// Source is an injectable stream of filesystem events. Production code uses
+// the fsnotify-backed source; tests use a fake.
+type Source interface {
+	Events() <-chan Event
+	Errors() <-chan error
+	Add(path string) error
+	Close() error
+}
+
+// Watcher re-runs a callback when files matching its patterns change.
+type Watcher struct {
+	patterns   []string
+	src        Source
+	debounce   time.Duration
+	log        logger.Logger
+	initialRun bool
+}
+
+// Option configures a Watcher.
+type Option func(*Watcher)
+
+// WithDebounce overrides the default debounce window.
+func WithDebounce(d time.Duration) Option { return func(w *Watcher) { w.debounce = d } }
+
+// WithLogger sets the logger (default: no-op).
+func WithLogger(l logger.Logger) Option { return func(w *Watcher) { w.log = l } }
+
+// WithInitialRun controls whether onChange fires once before watching
+// (default true).
+func WithInitialRun(b bool) Option { return func(w *Watcher) { w.initialRun = b } }
+
+// New builds a Watcher over the given patterns and event source.
+func New(patterns []string, src Source, opts ...Option) *Watcher {
+	w := &Watcher{
+		patterns:   patterns,
+		src:        src,
+		debounce:   DefaultDebounce,
+		log:        logger.Nop(),
+		initialRun: true,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+// Run blocks, invoking onChange on each debounced batch of matching changes,
+// until ctx is canceled. A failing onChange is logged but does not stop the
+// watch — the whole point is to keep iterating. New directories that appear
+// under watched trees are added automatically.
+func (w *Watcher) Run(ctx context.Context, onChange func(context.Context) error) error {
+	if w.initialRun {
+		w.invoke(ctx, onChange)
+	}
+
+	var debounceC <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case ev := <-w.src.Events():
+			// Auto-watch newly created directories so deeper files are seen.
+			if isDir(ev.Path) {
+				_ = w.src.Add(ev.Path)
+			}
+			if Matches(w.patterns, ev.Path) {
+				w.log.Debug("change detected", "path", ev.Path)
+				debounceC = time.After(w.debounce)
+			}
+
+		case <-debounceC:
+			debounceC = nil
+			w.invoke(ctx, onChange)
+
+		case err := <-w.src.Errors():
+			if err != nil {
+				w.log.Warn("watch source error", "err", err.Error())
+			}
+		}
+	}
+}
+
+func (w *Watcher) invoke(ctx context.Context, onChange func(context.Context) error) {
+	if err := onChange(ctx); err != nil {
+		w.log.Error("run failed; continuing to watch", "err", err.Error())
+	}
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,163 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSource lets tests drive events deterministically without real I/O.
+type fakeSource struct {
+	events chan Event
+	errs   chan error
+	mu     sync.Mutex
+	added  []string
+}
+
+func newFakeSource() *fakeSource {
+	return &fakeSource{events: make(chan Event, 16), errs: make(chan error, 4)}
+}
+
+func (s *fakeSource) Events() <-chan Event { return s.events }
+func (s *fakeSource) Errors() <-chan error { return s.errs }
+func (s *fakeSource) Add(p string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.added = append(s.added, p)
+	return nil
+}
+func (s *fakeSource) Close() error { return nil }
+
+func TestWatcher_InitialRun(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(10*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		_ = w.Run(ctx, func(context.Context) error {
+			atomic.AddInt32(&runs, 1)
+			return nil
+		})
+		close(done)
+	}()
+
+	// The initial run should fire without any event.
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) >= 1 }, time.Second, 5*time.Millisecond)
+	cancel()
+	<-done
+}
+
+func TestWatcher_RerunsOnMatchingChange(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(10*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+
+	src.events <- Event{Path: "main.go"}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
+}
+
+func TestWatcher_IgnoresNonMatchingChange(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(10*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+
+	src.events <- Event{Path: "README.md"}
+	// Give the loop time to (not) react.
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&runs))
+}
+
+func TestWatcher_DebouncesBurst(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(40*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+
+	// A rapid burst should collapse into a single run.
+	for range 5 {
+		src.events <- Event{Path: "main.go"}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
+	// Ensure it stays at exactly one for a bit.
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&runs))
+}
+
+func TestWatcher_FailingOnChangeKeepsWatching(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(10*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		_ = w.Run(ctx, func(context.Context) error {
+			atomic.AddInt32(&runs, 1)
+			return errors.New("boom")
+		})
+	}()
+
+	src.events <- Event{Path: "a.go"}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
+	// A second change still triggers another run despite the first failing.
+	src.events <- Event{Path: "b.go"}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 2 }, time.Second, 5*time.Millisecond)
+}
+
+func TestWatcher_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	w := New([]string{"*.go"}, src, WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx, func(context.Context) error { return nil }) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+func TestWatcher_SourceErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	var runs int32
+	w := New([]string{"*.go"}, src, WithDebounce(10*time.Millisecond), WithInitialRun(false))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+
+	src.errs <- errors.New("transient")
+	src.events <- Event{Path: "main.go"}
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
+}


### PR DESCRIPTION
## Summary

Adds `keepup watch [flow]`, a live inner-loop mode that re-runs a flow whenever its inputs change. It reuses the `cache.reads` declarations from the caching feature as the watch set, so no separate watch configuration is needed — and because caching short-circuits unchanged groups, only the work that actually depends on a changed file re-executes.

```sh
keepup watch dev   # build now, then rebuild on every matching change; Ctrl-C to stop
```

## How it works

1. Collect the union of `cache.reads` globs across the flow's groups (error if none declared — nothing to watch).
2. Resolve those globs to a set of directories and register them with an fsnotify watcher.
3. Run the flow once immediately, then on each debounced batch of matching changes, run it again with a fresh engine. The on-disk cache persists across runs, so unaffected groups are cache hits.

## New package: `internal/watch`

Designed so the event loop is unit-testable without real filesystem timing:

| File | Role |
|---|---|
| `match.go` | Pure helpers: `Matches` (doublestar `PathMatch`), `globBase` (longest non-glob prefix, absolute-path safe), `ResolveWatchDirs` (recursive dir walk covering `**`). |
| `watch.go` | `Source` interface + `Watcher.Run(ctx, onChange)` — debounce (200ms default), initial run, auto-watch of newly-created dirs, non-fatal run/source errors, clean stop on context cancel. |
| `fsnotify_source.go` | Production `Source` backed by fsnotify. |

The `Source` seam lets tests drive events deterministically via a fake; a separate integration test exercises the real fsnotify source against a temp dir.

## CLI

`cmd/watch.go` wires the flow's `cache.reads` → resolved dirs → fsnotify source → `Watcher.Run` with `onChange` building a fresh engine and calling `RunFlow`. Registered as `keepup watch [flow]`; honors `--config`, `--dry-run`, `--verbose`, and the default-flow resolution.

## Behavior verified end-to-end

```
keepup watch ci
→ running group / building        (initial run)
edit src/a.txt
→ running group / building        (re-run on change)
```

## Design notes

- **No new config surface.** Watch reuses `cache.reads`; the inputs that bust the cache are exactly the inputs that trigger a re-run. Consistent and DRY.
- **Debounce + cache** together prevent rebuild storms: bursts collapse into one pass, and that pass only runs changed groups.
- **Failing runs don't stop the watch** — fix and save again.
- **Ctrl-C/SIGTERM** propagate through the context; the in-flight run is cancelled and `watch` returns cleanly.
- New dep: `github.com/fsnotify/fsnotify`.

## Tests

- `internal/watch`: `Matches` table, `globBase` (incl. absolute + literal), `ResolveWatchDirs` (recursive, missing-base, literal-file), and the loop via a fake source — initial run, re-run on match, ignore non-match, burst debounce, failing-onChange-keeps-watching, stop-on-cancel, non-fatal source error. Plus a real fsnotify integration test (file write → re-run) and an Add-missing-dir error. 88.5% coverage.
- `cmd`: `watchPatterns` dedup/order, none-when-no-cache, error without `cache.reads`, error on unknown flow.

`go test -race ./...` clean; `golangci-lint run ./...` 0 issues.

## Docs

- `docs/CONFIG.md`: `keepup watch` in the subcommands list + how the watch set is derived.
- `docs/USAGE.md`: a Watch mode section with a runnable example; `--no-cache` noted.
- `docs/FAQ.md`: watch Q&A (what it watches, why it reuses `cache.reads`, debounce + cache, initial run, stopping, new-file handling).

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] End-to-end: initial run + re-run on real file edit verified with the built binary
- [ ] Try `keepup watch` against a real project flow