### PR TITLE
feat: keepup migrate — convert v1 configs to v2

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/quike/keepup/internal/migrate"
+)
+
+func newMigrateCmd(stdout io.Writer) *cobra.Command {
+	var (
+		outPath  string
+		flowName string
+	)
+	cmd := &cobra.Command{
+		Use:   "migrate <path>",
+		Short: "Convert a legacy v1 config file to the v2 schema",
+		Long: "Read a v1 keepup file and emit the v2 equivalent. Groups, env, and " +
+			"settings are preserved; the single v1 'execution' block becomes one " +
+			"step-mode flow. Output goes to stdout unless --output is given.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := os.ReadFile(filepath.Clean(args[0]))
+			if err != nil {
+				return fmt.Errorf("read %q: %w", args[0], err)
+			}
+			out, err := migrate.Migrate(data, migrate.Options{FlowName: flowName})
+			if err != nil {
+				return err
+			}
+			if outPath == "" {
+				_, err = stdout.Write(out)
+				return err
+			}
+			// outPath is a user-chosen destination for a CLI write; that is the
+			// command's purpose.
+			if err := os.WriteFile(filepath.Clean(outPath), out, 0o600); err != nil { //nolint:gosec // user-specified output path
+				return fmt.Errorf("write %q: %w", outPath, err)
+			}
+			fmt.Fprintf(stdout, "wrote %s\n", outPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Write the v2 config to this file instead of stdout")
+	cmd.Flags().StringVar(&flowName, "flow", migrate.DefaultFlowName, "Name for the flow synthesized from the v1 execution block")
+	return cmd
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const v1Doc = `
+version: 1
+settings:
+  logging:
+    level: info
+groups:
+  - name: a
+    command: echo
+    params: ["hi"]
+execution:
+  - group: ["a"]
+`
+
+func TestMigrateCmd_ToStdout(t *testing.T) {
+	t.Parallel()
+	src := writeTempConfig(t, v1Doc)
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"migrate", src})
+	require.NoError(t, cmd.Execute())
+
+	s := out.String()
+	assert.Contains(t, s, "version: 2")
+	assert.Contains(t, s, "flows:")
+	assert.Contains(t, s, "main:")
+}
+
+func TestMigrateCmd_ToFile(t *testing.T) {
+	t.Parallel()
+	src := writeTempConfig(t, v1Doc)
+	dst := filepath.Join(t.TempDir(), "v2.yml")
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"migrate", src, "-o", dst})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "wrote "+dst)
+	written, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "version: 2")
+}
+
+func TestMigrateCmd_CustomFlow(t *testing.T) {
+	t.Parallel()
+	src := writeTempConfig(t, v1Doc)
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"migrate", src, "--flow", "ci"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "ci:")
+	assert.Contains(t, out.String(), "default: ci")
+}
+
+func TestMigrateCmd_MissingFile(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"migrate", "/no/such/file.yml"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read")
+}
+
+func TestMigrateCmd_NotV1(t *testing.T) {
+	t.Parallel()
+	src := writeTempConfig(t, "version: 2\ngroups: []\n")
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"migrate", src})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a v1 document")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root.AddCommand(newListCmd(opts, stdout))
 	root.AddCommand(newValidateCmd(opts, stdout))
 	root.AddCommand(newGraphCmd(opts, stdout))
+	root.AddCommand(newMigrateCmd(stdout))
 	root.AddCommand(newVersionCmd())
 	return root
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -299,6 +299,7 @@ keepup list                  # show declared flows + descriptions
 keepup list groups           # show declared groups
 keepup validate              # parse + validate; no execution
 keepup graph [flow]          # emit a Mermaid diagram of the data DAG
+keepup migrate <path>        # convert a legacy v1 file to v2
 keepup version
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -35,9 +35,21 @@ Three reasons:
 3. **It's an early project.** There is no installed base big enough to
    justify a permanent shim. Today is the cheapest moment.
 
-If you do want an automated converter, a dedicated `keepup migrate <path>`
-subcommand is the cleanest follow-up (file an issue if you want it
-prioritized). The engine itself would stay single-schema.
+### Is there an automated converter?
+
+Yes — `keepup migrate`:
+
+```sh
+keepup migrate ~/.config/keepup/keepup.yml            # print v2 to stdout
+keepup migrate old.yml -o keepup.yml                   # write to a file
+keepup migrate old.yml --flow ci                       # name the generated flow
+```
+
+It preserves groups, env, and settings, turns the single v1 `execution:` block
+into one step-mode flow (the parallel waves are kept), and validates the result
+against the v2 parser before emitting — so a successful migration is guaranteed
+to load. The engine itself stays single-schema; `migrate` is the only code that
+understands v1.
 
 ### What changed in the YAML?
 
@@ -55,7 +67,8 @@ prioritized). The engine itself would stay single-schema.
 
 ### How do I migrate by hand?
 
-Two-step recipe:
+Prefer `keepup migrate` (above); but if you want to do it manually it's a
+two-step recipe:
 
 1. Bump `version: 1` to `version: 2`.
 2. Rename `execution:` to a flow under `flows:`, and rename each

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -58,6 +58,7 @@ keepup list               # list flows (default starred)
 keepup list groups        # list groups
 keepup validate           # parse & reference-check; no execution
 keepup graph [flow]       # emit a Mermaid diagram of the data DAG
+keepup migrate <path>     # convert a legacy v1 file to v2
 keepup version
 ```
 

--- a/internal/migrate/edge_cases_test.go
+++ b/internal/migrate/edge_cases_test.go
@@ -1,0 +1,275 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// migrateOK runs Migrate and parses the result, failing the test on any error.
+func migrateOK(t *testing.T, v1 string) (cfg *config.Config, out string) {
+	t.Helper()
+	raw, err := Migrate([]byte(v1), Options{})
+	require.NoError(t, err)
+	cfg, err = config.NewConfig(raw)
+	require.NoError(t, err)
+	return cfg, string(raw)
+}
+
+func TestMigrate_SettingsVariants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		v1     string
+		assert func(t *testing.T, cfg *config.Config, out string)
+	}{
+		{
+			name: "logging only",
+			v1: `version: 1
+settings:
+  logging:
+    level: trace
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`,
+			assert: func(t *testing.T, cfg *config.Config, out string) {
+				assert.Equal(t, "trace", cfg.Settings.Logging.Level)
+				assert.NotContains(t, out, "working-dir")
+				assert.NotContains(t, out, "max-concurrency")
+			},
+		},
+		{
+			name: "working-dir only",
+			v1: `version: 1
+settings:
+  working-dir: /srv
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`,
+			assert: func(t *testing.T, cfg *config.Config, out string) {
+				assert.Equal(t, "/srv", cfg.Settings.WorkingDir)
+				assert.NotContains(t, out, "logging")
+			},
+		},
+		{
+			name: "max-concurrency only",
+			v1: `version: 1
+settings:
+  max-concurrency: 8
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`,
+			assert: func(t *testing.T, cfg *config.Config, out string) {
+				assert.Equal(t, 8, cfg.Settings.MaxConcurrency)
+			},
+		},
+		{
+			name: "pretty true is preserved",
+			v1: `version: 1
+settings:
+  logging:
+    level: info
+    pretty: true
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`,
+			assert: func(t *testing.T, cfg *config.Config, out string) {
+				assert.True(t, cfg.Settings.Logging.Pretty)
+			},
+		},
+		{
+			name: "no settings block emits none",
+			v1: `version: 1
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`,
+			assert: func(t *testing.T, _ *config.Config, out string) {
+				assert.NotContains(t, out, "settings:")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, out := migrateOK(t, tc.v1)
+			tc.assert(t, cfg, out)
+		})
+	}
+}
+
+func TestMigrate_GroupFieldVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("per-group env preserved", func(t *testing.T) {
+		cfg, _ := migrateOK(t, `version: 1
+groups:
+  - name: a
+    command: echo
+    env:
+      FOO: bar
+execution: [{group: [a]}]`)
+		assert.Equal(t, "bar", cfg.GroupByName("a").Env["FOO"])
+	})
+
+	t.Run("group without params omits params key", func(t *testing.T) {
+		_, out := migrateOK(t, `version: 1
+groups:
+  - name: a
+    command: echo
+execution: [{group: [a]}]`)
+		assert.NotContains(t, out, "params")
+	})
+
+	t.Run("shell path preserved", func(t *testing.T) {
+		cfg, _ := migrateOK(t, `version: 1
+groups:
+  - name: a
+    command: omf
+    params: [update]
+    shell: /opt/homebrew/bin/fish
+execution: [{group: [a]}]`)
+		assert.Equal(t, "/opt/homebrew/bin/fish", cfg.GroupByName("a").Shell)
+	})
+
+	t.Run("global env preserved", func(t *testing.T) {
+		cfg, _ := migrateOK(t, `version: 1
+env:
+  GLOBAL: "1"
+groups: [{name: a, command: echo}]
+execution: [{group: [a]}]`)
+		assert.Equal(t, "1", cfg.Env["GLOBAL"])
+	})
+}
+
+func TestMigrate_ExecutionShapes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("many sequential steps keep order", func(t *testing.T) {
+		cfg, _ := migrateOK(t, `version: 1
+groups:
+  - {name: a, command: echo}
+  - {name: b, command: echo}
+  - {name: c, command: echo}
+execution:
+  - group: [a]
+  - group: [b]
+  - group: [c]`)
+		flow := cfg.Flows[DefaultFlowName]
+		require.Len(t, flow.Steps, 3)
+		assert.Equal(t, []string{"a"}, flow.Steps[0].Run)
+		assert.Equal(t, []string{"b"}, flow.Steps[1].Run)
+		assert.Equal(t, []string{"c"}, flow.Steps[2].Run)
+	})
+
+	t.Run("valid cross-step output reference migrates", func(t *testing.T) {
+		cfg, _ := migrateOK(t, `version: 1
+groups:
+  - {name: producer, command: echo, params: ["x"]}
+  - name: consumer
+    command: echo
+    params: ["{{ output.producer }}"]
+execution:
+  - group: [producer]
+  - group: [consumer]`)
+		assert.Len(t, cfg.Flows[DefaultFlowName].Steps, 2)
+	})
+}
+
+// TestMigrate_SurfacesLatentV1Bugs documents the most important class of edge
+// case: v1 never validated references or group definitions, so a file that
+// "worked" (or silently misbehaved) under v1 may be genuinely invalid. The
+// migrator validates its output against the v2 parser and refuses to emit a
+// broken file, surfacing the latent bug instead.
+func TestMigrate_SurfacesLatentV1Bugs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		v1      string
+		wantErr string
+	}{
+		{
+			name: "same-step output reference (a race in v1) is rejected",
+			v1: `version: 1
+groups:
+  - {name: a, command: echo, params: ["{{ output.b }}"]}
+  - {name: b, command: echo}
+execution:
+  - group: [a, b]`,
+			wantErr: "failed v2 validation",
+		},
+		{
+			name: "reference to a group not in the flow",
+			v1: `version: 1
+groups:
+  - {name: a, command: echo, params: ["{{ output.ghost }}"]}
+execution:
+  - group: [a]`,
+			wantErr: "failed v2 validation",
+		},
+		{
+			name: "execution references an undefined group",
+			v1: `version: 1
+groups:
+  - {name: a, command: echo}
+execution:
+  - group: [a, missing]`,
+			wantErr: "failed v2 validation",
+		},
+		{
+			name: "duplicate group name",
+			v1: `version: 1
+groups:
+  - {name: a, command: echo}
+  - {name: a, command: ls}
+execution:
+  - group: [a]`,
+			wantErr: "failed v2 validation",
+		},
+		{
+			name: "group missing command",
+			v1: `version: 1
+groups:
+  - {name: a}
+execution:
+  - group: [a]`,
+			wantErr: "failed v2 validation",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Migrate([]byte(tc.v1), Options{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestMigrate_VersionGuards(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		v1   string
+	}{
+		{"version 0 / missing", "groups: []\nexecution: []\n"},
+		{"version 2", "version: 2\ngroups: []\nexecution: []\n"},
+		{"version 3", "version: 3\ngroups: []\nexecution: []\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Migrate([]byte(tc.v1), Options{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not a v1 document")
+		})
+	}
+}
+
+func TestMigrate_OutputIsStableAndParseable(t *testing.T) {
+	t.Parallel()
+	// Migrating twice (v1 → v2, then feed v2 back through v1 parse) must reject
+	// the v2 output as "not v1", proving the output is unambiguously v2.
+	out, err := Migrate([]byte(v1Sample), Options{})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(out)), "version: 2"))
+
+	_, err = Migrate(out, Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a v1 document")
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,197 @@
+// Package migrate converts a legacy v1 keepup file into the v2 schema.
+//
+// v1 declared a single top-level `execution:` list of `group:` waves. v2
+// replaces that with named `flows:`. migrate maps the single execution chain
+// into one step-mode flow, leaving groups, env, and settings otherwise intact.
+package migrate
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// DefaultFlowName is the name given to the flow synthesized from v1 `execution`.
+const DefaultFlowName = "main"
+
+// --- v1 input schema (independent of the live config package) ---
+
+type v1Doc struct {
+	Version   int               `yaml:"version"`
+	Settings  v1Settings        `yaml:"settings"`
+	Env       map[string]string `yaml:"env"`
+	Groups    []v1Group         `yaml:"groups"`
+	Execution []v1Step          `yaml:"execution"`
+}
+
+type v1Settings struct {
+	Logging        v1Logging `yaml:"logging"`
+	WorkingDir     string    `yaml:"working-dir"`
+	MaxConcurrency int       `yaml:"max-concurrency"`
+}
+
+type v1Logging struct {
+	Level  string `yaml:"level"`
+	Pretty bool   `yaml:"pretty"`
+}
+
+type v1Group struct {
+	Name        string            `yaml:"name"`
+	Command     string            `yaml:"command"`
+	Params      []string          `yaml:"params"`
+	Shell       string            `yaml:"shell"`
+	Description string            `yaml:"description"`
+	Env         map[string]string `yaml:"env"`
+}
+
+type v1Step struct {
+	Group []string `yaml:"group"`
+}
+
+// --- v2 output schema (omitempty everywhere for clean output) ---
+
+type v2Doc struct {
+	Version  int               `yaml:"version"`
+	Settings *v2Settings       `yaml:"settings,omitempty"`
+	Env      map[string]string `yaml:"env,omitempty"`
+	Groups   []v2Group         `yaml:"groups"`
+	Default  string            `yaml:"default,omitempty"`
+	Flows    map[string]v2Flow `yaml:"flows"`
+}
+
+type v2Settings struct {
+	Logging        *v2Logging `yaml:"logging,omitempty"`
+	WorkingDir     string     `yaml:"working-dir,omitempty"`
+	MaxConcurrency int        `yaml:"max-concurrency,omitempty"`
+}
+
+type v2Logging struct {
+	Level  string `yaml:"level,omitempty"`
+	Pretty bool   `yaml:"pretty,omitempty"`
+}
+
+type v2Group struct {
+	Name        string            `yaml:"name"`
+	Command     string            `yaml:"command"`
+	Params      []string          `yaml:"params,omitempty"`
+	Shell       string            `yaml:"shell,omitempty"`
+	Description string            `yaml:"description,omitempty"`
+	Env         map[string]string `yaml:"env,omitempty"`
+}
+
+type v2Flow struct {
+	Description string   `yaml:"description,omitempty"`
+	Mode        string   `yaml:"mode"`
+	Steps       []v2Step `yaml:"steps"`
+}
+
+type v2Step struct {
+	Run []string `yaml:"run"`
+}
+
+// Options configures a migration.
+type Options struct {
+	// FlowName is the name for the flow synthesized from `execution`.
+	// Defaults to DefaultFlowName when empty.
+	FlowName string
+}
+
+// Migrate parses v1 YAML bytes and returns the equivalent v2 YAML document.
+// The result is validated against the live v2 parser before being returned, so
+// a successful migration is guaranteed to load.
+func Migrate(data []byte, opts Options) ([]byte, error) {
+	v1, err := parseV1(data)
+	if err != nil {
+		return nil, err
+	}
+	flowName := opts.FlowName
+	if flowName == "" {
+		flowName = DefaultFlowName
+	}
+	doc := convert(v1, flowName)
+
+	out, err := marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	// Guarantee the output is a valid v2 document.
+	if _, err := config.NewConfig(out); err != nil {
+		return nil, fmt.Errorf("migrated output failed v2 validation: %w", err)
+	}
+	return out, nil
+}
+
+func parseV1(data []byte) (*v1Doc, error) {
+	var doc v1Doc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse v1 yaml: %w", err)
+	}
+	if doc.Version != 1 {
+		return nil, fmt.Errorf("not a v1 document: version is %d (expected 1)", doc.Version)
+	}
+	if len(doc.Execution) == 0 {
+		return nil, fmt.Errorf("v1 document has no 'execution' block to migrate")
+	}
+	return &doc, nil
+}
+
+func convert(v1 *v1Doc, flowName string) *v2Doc {
+	doc := &v2Doc{
+		Version: 2,
+		Env:     v1.Env,
+		Default: flowName,
+		Flows:   map[string]v2Flow{},
+	}
+
+	if s := convertSettings(v1.Settings); s != nil {
+		doc.Settings = s
+	}
+
+	doc.Groups = make([]v2Group, len(v1.Groups))
+	for i, g := range v1.Groups {
+		// v1Group and v2Group share an identical field layout.
+		doc.Groups[i] = v2Group(g)
+	}
+
+	steps := make([]v2Step, len(v1.Execution))
+	for i, s := range v1.Execution {
+		steps[i] = v2Step{Run: s.Group}
+	}
+	doc.Flows[flowName] = v2Flow{
+		Description: "Migrated from v1 execution",
+		Mode:        "step",
+		Steps:       steps,
+	}
+	return doc
+}
+
+func convertSettings(s v1Settings) *v2Settings {
+	out := &v2Settings{
+		WorkingDir:     s.WorkingDir,
+		MaxConcurrency: s.MaxConcurrency,
+	}
+	if s.Logging.Level != "" || s.Logging.Pretty {
+		out.Logging = &v2Logging{Level: s.Logging.Level, Pretty: s.Logging.Pretty}
+	}
+	// Drop a wholly-empty settings block so the output stays clean.
+	if out.Logging == nil && out.WorkingDir == "" && out.MaxConcurrency == 0 {
+		return nil
+	}
+	return out
+}
+
+func marshal(doc *v2Doc) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encode v2 yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close yaml encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,143 @@
+package migrate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+const v1Sample = `
+version: 1
+settings:
+  logging:
+    level: debug
+    pretty: true
+  working-dir: /tmp
+  max-concurrency: 2
+env:
+  KEY: value
+groups:
+  - name: a
+    description: "first"
+    command: echo
+    params: ["hello"]
+  - name: b
+    command: echo
+    params: ["{{ output.a }}"]
+    shell: /bin/sh
+execution:
+  - group: ["a"]
+  - group: ["b"]
+`
+
+func TestMigrate_HappyPath(t *testing.T) {
+	t.Parallel()
+	out, err := Migrate([]byte(v1Sample), Options{})
+	require.NoError(t, err)
+
+	// The output must be a valid v2 document.
+	cfg, err := config.NewConfig(out)
+	require.NoError(t, err)
+	assert.Equal(t, 2, cfg.Version)
+	assert.Equal(t, DefaultFlowName, cfg.Default)
+
+	// Groups preserved 1:1, including shell.
+	require.Len(t, cfg.Groups, 2)
+	assert.Equal(t, "echo", cfg.GroupByName("a").Command)
+	assert.Equal(t, "/bin/sh", cfg.GroupByName("b").Shell)
+
+	// Settings + env carried over.
+	assert.Equal(t, "/tmp", cfg.Settings.WorkingDir)
+	assert.Equal(t, 2, cfg.Settings.MaxConcurrency)
+	assert.Equal(t, "debug", cfg.Settings.Logging.Level)
+	assert.Equal(t, "value", cfg.Env["KEY"])
+
+	// execution → a single step-mode flow with the same wave shape.
+	flow := cfg.Flows[DefaultFlowName]
+	assert.Equal(t, config.ModeStep, flow.Mode)
+	require.Len(t, flow.Steps, 2)
+	assert.Equal(t, []string{"a"}, flow.Steps[0].Run)
+	assert.Equal(t, []string{"b"}, flow.Steps[1].Run)
+}
+
+func TestMigrate_CustomFlowName(t *testing.T) {
+	t.Parallel()
+	out, err := Migrate([]byte(v1Sample), Options{FlowName: "ci"})
+	require.NoError(t, err)
+	cfg, err := config.NewConfig(out)
+	require.NoError(t, err)
+	assert.Equal(t, "ci", cfg.Default)
+	assert.Contains(t, cfg.Flows, "ci")
+}
+
+func TestMigrate_ParallelWavePreserved(t *testing.T) {
+	t.Parallel()
+	v1 := `
+version: 1
+groups:
+  - { name: x, command: echo }
+  - { name: y, command: echo }
+execution:
+  - group: ["x", "y"]
+`
+	out, err := Migrate([]byte(v1), Options{})
+	require.NoError(t, err)
+	cfg, err := config.NewConfig(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x", "y"}, cfg.Flows[DefaultFlowName].Steps[0].Run)
+}
+
+func TestMigrate_Errors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"already v2", "version: 2\ngroups: []\n", "not a v1 document"},
+		{"missing version", "groups: []\n", "not a v1 document"},
+		{"no execution", "version: 1\ngroups:\n  - {name: a, command: echo}\n", "no 'execution' block"},
+		{"bad yaml", "version: 1\nexecution: [", "parse v1 yaml"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Migrate([]byte(tc.input), Options{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestMigrate_RealV1Fixture(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("../config/test-resources/config-valid-example-v1.yml")
+	require.NoError(t, err)
+
+	out, err := Migrate(data, Options{FlowName: "update"})
+	require.NoError(t, err)
+
+	cfg, err := config.NewConfig(out)
+	require.NoError(t, err)
+	assert.Equal(t, "update", cfg.Default)
+	require.Len(t, cfg.Groups, 7) // brew-* + omf-* + fisher-update
+	// The original 6-wave execution is preserved, incl. the parallel pair.
+	flow := cfg.Flows["update"]
+	require.Len(t, flow.Steps, 6)
+	assert.Equal(t, []string{"omf-update", "fisher-update"}, flow.Steps[4].Run)
+}
+
+func TestMigrate_OutputHasNoEmptyNoise(t *testing.T) {
+	t.Parallel()
+	// A minimal v1 with no settings must not emit an empty settings block.
+	v1 := "version: 1\ngroups:\n  - {name: a, command: echo}\nexecution:\n  - group: [a]\n"
+	out, err := Migrate([]byte(v1), Options{})
+	require.NoError(t, err)
+	s := string(out)
+	assert.NotContains(t, s, "settings:")
+	assert.NotContains(t, s, "working-dir")
+	assert.Contains(t, s, "version: 2")
+}


### PR DESCRIPTION
## Summary

Adds `keepup migrate <path>`, a one-shot converter from the legacy v1 schema to v2. This closes the migration story: the "v1 is rejected" hard error now always has a one-command escape hatch.

```sh
keepup migrate ~/.config/keepup/keepup.yml          # print v2 to stdout
keepup migrate old.yml -o keepup.yml                 # write to a file
keepup migrate old.yml --flow ci                     # name the generated flow
```

## What it does

- Parses v1 with an **independent** v1 schema (the live `config` package stays single-schema — only `internal/migrate` understands v1).
- Preserves `groups`, `env`, and `settings` (logging / working-dir / max-concurrency) verbatim.
- Turns the single v1 `execution:` block into **one step-mode flow**, keeping the exact wave shape (parallel groups stay parallel). Sets `default:` to that flow.
- Emits clean YAML (omitempty everywhere — no `working-dir: ""` / `dry-run: false` noise).
- **Validates its own output** against the v2 parser before emitting, so a successful migration is guaranteed to load.

## Components

| File | Role |
|---|---|
| `internal/migrate/migrate.go` | v1 input structs, clean v2 output structs, `Migrate(data, Options)` → validated v2 YAML. |
| `cmd/migrate.go` | `keepup migrate <path>` with `-o/--output` and `--flow`. |

## A deliberate behavior: latent v1 bugs surface on migrate

v1 never validated references or group definitions, so a file that "worked" (or silently misbehaved) under v1 may be genuinely invalid. Because migrate validates its output, it refuses to emit a broken file and surfaces the real problem instead. Covered by tests:

- a **same-step** `{{ output.X }}` reference (a race under v1) → rejected
- a reference to a group not in the flow → rejected
- `execution` naming an undefined group → rejected
- duplicate group names → rejected
- a group missing `command` → rejected

This is the right call: rather than carrying a subtle bug into v2, the user is told exactly what to fix.

## Tests

- **Happy path**: groups (incl. shell), env, settings, and the execution→flow mapping all verified; custom `--flow`; parallel-wave preservation.
- **Settings variants**: logging-only, working-dir-only, max-concurrency-only, pretty=true, none (no empty block emitted).
- **Group fields**: per-group env, global env, shell path, params omitted when empty.
- **Execution shapes**: many sequential steps in order; valid cross-step output reference.
- **Latent-bug surfacing**: the five cases above.
- **Version guards**: missing/0, 2, 3 all rejected as "not a v1 document".
- **Real fixture**: migrates `config-valid-example-v1.yml` (your brew/fish config) and asserts the 6-wave shape incl. the `omf-update`+`fisher-update` parallel pair.
- **Output is unambiguously v2**: re-feeding the output to `Migrate` is rejected.
- `cmd`: stdout, `-o` file, `--flow`, missing-file, not-v1.

`internal/migrate` 93.5% coverage; `go test -race ./...` clean; `golangci-lint run ./...` 0 issues.

## Docs

- CONFIG.md / USAGE.md: `keepup migrate` added to the subcommand lists.
- FAQ.md: the "Is there an automated converter?" answer now documents the command and its validate-before-emit guarantee.

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] Smoke-tested: migrated the real v1 fixture, round-tripped the output through `keepup validate`
- [ ] Migrate a real personal config and run a flow from the result