### PR TITLE
feat: per-step and per-flow timeout and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,43 @@
 
 Simple task runner.
 
+keepup runs YAML-declared **groups** of commands composed into named **flows**.
+Groups are atomic and reusable; flows decide how they run — either as ordered
+parallel waves (**step mode**) or scheduled automatically from the data
+dependencies between them (**dag mode**). Data flows between groups through
+`{{ output.<name> }}` references, which keepup validates up front. A single
+binary, no runtime, safe-by-default execution (no shell unless you ask for it),
+and incremental re-runs via content-based caching.
+
+## Features
+
+| Feature                  | What it gives you                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **Groups + flows**       | Reusable command units composed into many named pipelines in one file — no duplication.                                     |
+| **Two scheduling modes** | `step` (explicit parallel waves with barriers) or `dag` (topological, inferred from `{{ output.X }}` data deps).            |
+| **Output piping**        | Pass one group's captured stdout into another via `{{ output.name }}`, validated at load time.                              |
+| **Caching**              | Per-group `cache: { reads, writes }` fingerprints inputs (hash or mtime) and skips unchanged work, replaying stored output. |
+| **Watch mode**           | `keepup watch` re-runs a flow on file changes (using each group's `cache.reads`); caching makes unaffected groups no-ops.   |
+| **Gating**               | `require:` (must pass) and `skip-if:` (skip when already done) predicates short-circuit a group before it runs.             |
+| **Timeouts & retries**   | Per-step / per-flow `timeout` and `retries` envelope around each command attempt, with backoff.                             |
+| **Safe execution**       | Commands run as real argv by default (no shell injection); opt into a shell per group with `shell:`.                        |
+| **Env layering**         | Global `env:` plus per-group overrides, merged over the process environment.                                                |
+| **Discoverability**      | `keepup list`, `keepup validate`, and `keepup graph` (Mermaid diagram of the data DAG).                                     |
+| **Migration**            | `keepup migrate` converts legacy v1 configs to v2 and validates the result.                                                 |
+
+## Quick start
+
+```sh
+keepup run            # run the default flow
+keepup run ci         # run a named flow
+keepup watch dev      # re-run on file changes
+keepup list           # show flows; `list groups` shows groups
+keepup graph ci       # Mermaid diagram of the data DAG
+```
+
 ## Documentation
 
 - [Index](docs/index.md)
+- [Usage](docs/USAGE.md) — quick tour of the CLI
+- [Configuration](docs/CONFIG.md) — full schema reference
+- [FAQ](docs/FAQ.md) — flows, modes, caching, migration

--- a/docs/CODESTYLE.md
+++ b/docs/CODESTYLE.md
@@ -2,7 +2,6 @@
 
 ## Code Editor Configuration
 
-Code Style is defined into `.editorconfig` at root level. Please check your IDE availability plugin in
-[here](https://editorconfig.org/#download).
+Code Style is defined into `.editorconfig` at root level. Please check your [IDE availability plugin](https://editorconfig.org/#download).
 
 More information [editorconfig.org](https://editorconfig.org)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -277,6 +277,42 @@ Both modes share the same `Runner`, output capture, env merging,
 `max-concurrency`, and `--dry-run` semantics; they only differ at
 scheduling time.
 
+### Timeout and retries
+
+A flow can declare a control envelope that wraps each group's command run:
+
+```yaml
+flows:
+  release:
+    timeout: 10m # default per-group timeout for the whole flow
+    retries: 1 # default retries on failure
+    steps:
+      - run: [build]
+        timeout: 5m # override for this wave
+        retries: 2
+      - run: [smoke]
+        timeout: 30s
+```
+
+| Field | Where | Meaning |
+|-------|-------|---------|
+| `timeout` | flow and/or step | A Go duration (`30s`, `5m`, `1h`). Each command **attempt** is cancelled if it exceeds this. Empty/absent = no timeout. |
+| `retries` | flow and/or step | Number of **additional** attempts after the first failure. `0` = no retry. |
+
+Resolution: a step's non-empty `timeout` / non-zero `retries` override the
+flow defaults; otherwise the flow values apply. In **dag mode** there are no
+steps, so the flow-level values are the only envelope.
+
+Semantics:
+
+- The envelope wraps only the **command run** — gating predicates (`require`,
+  `skip-if`) and cache lookups are not retried or timed out.
+- Each retry attempt gets its own fresh timeout.
+- Between attempts there is a short backoff (`base × attempt`); it respects
+  Ctrl-C / context cancellation.
+- A cache write happens only after a successful attempt, so a timed-out or
+  failed run never poisons the cache.
+
 ---
 
 ## `default`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -46,14 +46,14 @@ settings:
     pretty: true # true = human; false = JSON lines.
 ```
 
-| Field             | Default          | Notes                                                                                                                         |
-| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `dry-run`         | `false`          | When true, the runner is bypassed for every group. The CLI `--dry-run` flag also forces this on regardless of the file value. |
-| `working-dir`     | `""`             | Currently reserved. Not consumed by the runner yet.                                                                           |
-| `max-concurrency` | `0` (unbounded)  | Caps the number of groups running concurrently across both step- and dag-mode schedulers.                                     |
-| `cache-dir`       | `.keepup-cache`  | Directory where per-group cache fingerprints/outputs are stored (see [Caching](#caching)).                                    |
-| `logging.level`   | `info`           | Standard severity ladder. Invalid values fall back to `info`.                                                                 |
-| `logging.pretty`  | `false`          | `true` for the human renderer, `false` for one JSON object per line.                                                          |
+| Field             | Default         | Notes                                                                                                                         |
+| ----------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `dry-run`         | `false`         | When true, the runner is bypassed for every group. The CLI `--dry-run` flag also forces this on regardless of the file value. |
+| `working-dir`     | `""`            | Currently reserved. Not consumed by the runner yet.                                                                           |
+| `max-concurrency` | `0` (unbounded) | Caps the number of groups running concurrently across both step- and dag-mode schedulers.                                     |
+| `cache-dir`       | `.keepup-cache` | Directory where per-group cache fingerprints/outputs are stored (see [Caching](#caching)).                                    |
+| `logging.level`   | `info`          | Standard severity ladder. Invalid values fall back to `info`.                                                                 |
+| `logging.pretty`  | `false`         | `true` for the human renderer, `false` for one JSON object per line.                                                          |
 
 ---
 
@@ -96,8 +96,8 @@ groups:
 | `env`         | map        | no       | Per-group env overrides; applied on top of the global `env`.                                                            |
 | `shell`       | string     | no       | When non-empty, the named shell program runs `command + params` as a single shell-interpreted line (opt-in shell mode). |
 | `description` | string     | no       | Free text used by `keepup list groups`.                                                                                 |
-| `require`     | string     | no       | Predicate command; non-zero exit fails the group before it runs (see [Gating](#gating-skip-if-and-require)).             |
-| `skip-if`     | string     | no       | Predicate command; exit 0 skips the group (see [Gating](#gating-skip-if-and-require)).                                   |
+| `require`     | string     | no       | Predicate command; non-zero exit fails the group before it runs (see [Gating](#gating-skip-if-and-require)).            |
+| `skip-if`     | string     | no       | Predicate command; exit 0 skips the group (see [Gating](#gating-skip-if-and-require)).                                  |
 | `cache`       | map        | no       | Skip the group when declared inputs are unchanged (see [Caching](#caching)).                                            |
 
 ### Direct exec vs. shell mode
@@ -164,9 +164,9 @@ groups:
     skip-if: "test -d /var/cache/app" # exit 0 → skip the group entirely
 ```
 
-| Field | Meaning | On match |
-|-------|---------|----------|
-| `require` | Precondition that must hold | Non-zero exit → the group (and its flow) fails with a clear error. |
+| Field     | Meaning                                   | On match                                                                                                |
+| --------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `require` | Precondition that must hold               | Non-zero exit → the group (and its flow) fails with a clear error.                                      |
 | `skip-if` | Condition under which work is unnecessary | Exit 0 → the group is skipped; its output is the last cached value if `cache:` is set, otherwise empty. |
 
 Evaluation order per group: `require` → `skip-if` → `cache` → run. In
@@ -191,11 +191,11 @@ groups:
       writes: ["bin/keepup"] # optional; must still exist for a hit
 ```
 
-| Field | Default | Meaning |
-|-------|---------|---------|
-| `method` | `hash` | `hash` reads file contents (correct); `mtime` uses modtime+size (faster, coarser). |
-| `reads` | — (required) | Input paths/globs. The fingerprint also folds in `command` + `params`, so changing the command busts the cache. |
-| `writes` | `[]` | Output paths/globs. If any declared output is missing, the cache is treated as a miss and the group re-runs. |
+| Field    | Default      | Meaning                                                                                                         |
+| -------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
+| `method` | `hash`       | `hash` reads file contents (correct); `mtime` uses modtime+size (faster, coarser).                              |
+| `reads`  | — (required) | Input paths/globs. The fingerprint also folds in `command` + `params`, so changing the command busts the cache. |
+| `writes` | `[]`         | Output paths/globs. If any declared output is missing, the cache is treated as a miss and the group re-runs.    |
 
 Mechanics:
 
@@ -294,10 +294,10 @@ flows:
         timeout: 30s
 ```
 
-| Field | Where | Meaning |
-|-------|-------|---------|
+| Field     | Where            | Meaning                                                                                                                 |
+| --------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `timeout` | flow and/or step | A Go duration (`30s`, `5m`, `1h`). Each command **attempt** is cancelled if it exceeds this. Empty/absent = no timeout. |
-| `retries` | flow and/or step | Number of **additional** attempts after the first failure. `0` = no retry. |
+| `retries` | flow and/or step | Number of **additional** attempts after the first failure. `0` = no retry.                                              |
 
 Resolution: a step's non-empty `timeout` / non-zero `retries` override the
 flow defaults; otherwise the flow values apply. In **dag mode** there are no

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -207,6 +207,18 @@ The first error in a step (step mode) or anywhere in the DAG (dag mode)
 cancels its siblings via the shared `errgroup` context. The flow then
 returns the wrapped error. Subsequent steps are not started.
 
+### How do timeouts and retries work?
+
+Declare them on a flow (the default for every group) and/or on a step (an
+override for that wave). `timeout` is a Go duration applied to each command
+**attempt**; `retries` is the number of additional attempts after the first
+failure. They wrap only the command run — `require`/`skip-if` predicates and
+cache lookups are never retried or timed out. Each attempt gets a fresh
+timeout, there's a short backoff between attempts (which respects Ctrl-C), and
+the cache is written only on success, so a failed/timed-out run can't poison
+it. In dag mode there are no steps, so the flow-level values are the only
+envelope.
+
 ---
 
 ## Caching and gating

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -236,7 +236,7 @@ refreshes the entry.
 
 Under `settings.cache-dir` (default `.keepup-cache`), one JSON file per group
 containing the fingerprint and the captured output. It's a build artifact —
-add it to `.gitignore`. You *can* point `cache-dir` at a shared volume to
+add it to `.gitignore`. You _can_ point `cache-dir` at a shared volume to
 share hits across machines or CI runners, since the fingerprint is
 content-based.
 
@@ -264,11 +264,11 @@ real question. They compose — `require` → `skip-if` → `cache` → run.
 
 A `cache` hit replays the stored output. A `skip-if` skip publishes the last
 cached output if the group also has a `cache:` block, otherwise an empty
-string. Downstream references always resolve to *something*, never an error.
+string. Downstream references always resolve to _something_, never an error.
 
 ### Do predicates and caching run during `--dry-run`?
 
-No. Dry-run logs what *would* happen and evaluates neither predicates nor the
+No. Dry-run logs what _would_ happen and evaluates neither predicates nor the
 cache, so it never touches disk or spawns shells.
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -109,16 +110,27 @@ func (g *Group) UseShell() bool { return g.Shell != "" }
 // Exactly one of Steps or Run must be set, matching Mode:
 //   - Mode == ModeStep (default): use Steps
 //   - Mode == ModeDAG:            use Run
+//
+// Timeout and Retries form a default control envelope applied to every group
+// in the flow. In step mode a Step may override them for its own wave; in dag
+// mode the flow-level values are the only knob (there are no steps).
 type Flow struct {
 	Description string   `yaml:"description,omitempty"`
 	Mode        Mode     `yaml:"mode,omitempty"`
 	Steps       []Step   `yaml:"steps,omitempty"`
 	Run         []string `yaml:"run,omitempty"`
+	Timeout     string   `yaml:"timeout,omitempty"`
+	Retries     int      `yaml:"retries,omitempty"`
 }
 
 // Step is one execution wave inside a step-mode Flow.
+//
+// Timeout (a Go duration string, e.g. "30s") and Retries override the flow's
+// envelope for this wave. An empty Timeout / zero Retries means "inherit".
 type Step struct {
-	Run []string `yaml:"run"`
+	Run     []string `yaml:"run"`
+	Timeout string   `yaml:"timeout,omitempty"`
+	Retries int      `yaml:"retries,omitempty"`
 }
 
 // NewConfig parses YAML bytes into a Config and validates the schema.
@@ -254,8 +266,46 @@ func (c *Config) validateFlow(name string, f *Flow, groups map[string]*Group) er
 			return fmt.Errorf("flow %q: group %q is not defined", name, member)
 		}
 	}
+	if err := validateEnvelope(name, f); err != nil {
+		return err
+	}
 	// Persist the normalised Mode back to the map.
 	c.Flows[name] = *f
+	return nil
+}
+
+// validateEnvelope checks the timeout/retries control envelope on a flow and
+// its steps: timeouts must be valid Go durations and retries non-negative.
+func validateEnvelope(name string, f *Flow) error {
+	if err := checkTimeout(f.Timeout); err != nil {
+		return fmt.Errorf("flow %q: %w", name, err)
+	}
+	if f.Retries < 0 {
+		return fmt.Errorf("flow %q: retries must be >= 0", name)
+	}
+	for i := range f.Steps {
+		s := &f.Steps[i]
+		if err := checkTimeout(s.Timeout); err != nil {
+			return fmt.Errorf("flow %q step %d: %w", name, i+1, err)
+		}
+		if s.Retries < 0 {
+			return fmt.Errorf("flow %q step %d: retries must be >= 0", name, i+1)
+		}
+	}
+	return nil
+}
+
+func checkTimeout(s string) error {
+	if s == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid timeout %q: %w", s, err)
+	}
+	if d < 0 {
+		return fmt.Errorf("timeout %q must not be negative", s)
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -317,6 +317,42 @@ flows:
 	}
 }
 
+func TestLoadConfig_EnvelopeResources(t *testing.T) {
+	t.Run("valid envelope fixture parses with all edges", func(t *testing.T) {
+		cfg, err := LoadConfig("./test-resources/config-envelope.yml")
+		require.NoError(t, err)
+
+		rel := cfg.Flows["release"]
+		assert.Equal(t, "1m", rel.Timeout)
+		assert.Equal(t, 2, rel.Retries)
+		require.Len(t, rel.Steps, 3)
+		// step a: no overrides
+		assert.Empty(t, rel.Steps[0].Timeout)
+		assert.Equal(t, 0, rel.Steps[0].Retries)
+		// step b: timeout override, retries left at 0
+		assert.Equal(t, "10s", rel.Steps[1].Timeout)
+		assert.Equal(t, 0, rel.Steps[1].Retries)
+		// step c: both overridden
+		assert.Equal(t, "5s", rel.Steps[2].Timeout)
+		assert.Equal(t, 5, rel.Steps[2].Retries)
+
+		dag := cfg.Flows["fast-dag"]
+		assert.Equal(t, ModeDAG, dag.Mode)
+		assert.Equal(t, "30s", dag.Timeout)
+		assert.Equal(t, 1, dag.Retries)
+
+		bare := cfg.Flows["bare"]
+		assert.Empty(t, bare.Timeout)
+		assert.Equal(t, 0, bare.Retries)
+	})
+
+	t.Run("bad-timeout fixture is rejected", func(t *testing.T) {
+		_, err := LoadConfig("./test-resources/config-bad-timeout.yml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid timeout")
+	})
+}
+
 func TestLoadConfig(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -244,6 +244,79 @@ flows:
 	})
 }
 
+func TestNewConfig_Envelope(t *testing.T) {
+	t.Run("valid timeout/retries on flow and step parse", func(t *testing.T) {
+		cfg, err := NewConfig([]byte(`
+version: 2
+groups:
+  - {name: a, command: echo}
+flows:
+  f:
+    timeout: 1m
+    retries: 3
+    steps:
+      - run: [a]
+        timeout: 30s
+        retries: 1
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "1m", cfg.Flows["f"].Timeout)
+		assert.Equal(t, 3, cfg.Flows["f"].Retries)
+		assert.Equal(t, "30s", cfg.Flows["f"].Steps[0].Timeout)
+		assert.Equal(t, 1, cfg.Flows["f"].Steps[0].Retries)
+	})
+
+	t.Run("dag flow accepts flow-level envelope", func(t *testing.T) {
+		cfg, err := NewConfig([]byte(`
+version: 2
+groups:
+  - {name: a, command: echo}
+flows:
+  f:
+    mode: dag
+    timeout: 5s
+    retries: 2
+    run: [a]
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "5s", cfg.Flows["f"].Timeout)
+	})
+
+	errCases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name:    "invalid flow timeout",
+			yaml:    "version: 2\ngroups:\n  - {name: a, command: echo}\nflows:\n  f:\n    timeout: nope\n    steps:\n      - run: [a]\n",
+			wantErr: "invalid timeout",
+		},
+		{
+			name:    "invalid step timeout",
+			yaml:    "version: 2\ngroups:\n  - {name: a, command: echo}\nflows:\n  f:\n    steps:\n      - run: [a]\n        timeout: 10furlongs\n",
+			wantErr: "invalid timeout",
+		},
+		{
+			name:    "negative flow retries",
+			yaml:    "version: 2\ngroups:\n  - {name: a, command: echo}\nflows:\n  f:\n    retries: -1\n    steps:\n      - run: [a]\n",
+			wantErr: "retries must be >= 0",
+		},
+		{
+			name:    "negative step retries",
+			yaml:    "version: 2\ngroups:\n  - {name: a, command: echo}\nflows:\n  f:\n    steps:\n      - run: [a]\n        retries: -2\n",
+			wantErr: "retries must be >= 0",
+		},
+	}
+	for _, tc := range errCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewConfig([]byte(tc.yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/config/test-resources/config-bad-timeout.yml
+++ b/internal/config/test-resources/config-bad-timeout.yml
@@ -1,0 +1,13 @@
+---
+# Invalid: the flow timeout is not a parseable Go duration. LoadConfig must
+# reject it at parse time.
+version: 2
+
+groups:
+  - { name: a, command: echo }
+
+flows:
+  f:
+    timeout: not-a-duration
+    steps:
+      - run: [a]

--- a/internal/config/test-resources/config-envelope.yml
+++ b/internal/config/test-resources/config-envelope.yml
@@ -1,0 +1,47 @@
+---
+# Exercises the timeout/retries control envelope across its edges:
+#   - a step that inherits both flow defaults
+#   - a step that overrides timeout but leaves retries at 0 (which means
+#     "inherit", a documented limitation — you cannot override down to 0)
+#   - a step that overrides both
+#   - a dag flow that has no steps, so the flow-level envelope is the only knob
+#   - a flow with no envelope at all
+version: 2
+
+settings:
+  logging:
+    level: info
+    pretty: true
+
+groups:
+  - { name: a, command: echo, params: ["a"] }
+  - { name: b, command: echo, params: ["b"] }
+  - { name: c, command: echo, params: ["c"] }
+
+default: release
+
+flows:
+  release:
+    description: "Flow envelope with per-step overrides and inherits"
+    timeout: 1m
+    retries: 2
+    steps:
+      - run: [a] # inherits flow: 1m / 2
+      - run: [b]
+        timeout: 10s # override timeout; retries 0 → inherit flow's 2
+        retries: 0
+      - run: [c]
+        timeout: 5s # override both
+        retries: 5
+
+  fast-dag:
+    description: "Dag flow uses the flow-level envelope (no steps)"
+    mode: dag
+    timeout: 30s
+    retries: 1
+    run: [a, b, c]
+
+  bare:
+    description: "No envelope at all"
+    steps:
+      - run: [a]

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -28,7 +28,12 @@ type Engine struct {
 	maxConcurrency int
 	dryRun         bool
 	noCache        bool
+	retryBackoff   time.Duration
 }
+
+// DefaultRetryBackoff is the base delay between retry attempts; the delay for
+// attempt N is DefaultRetryBackoff * N.
+const DefaultRetryBackoff = 250 * time.Millisecond
 
 // Option configures an Engine.
 type Option func(*Engine)
@@ -57,6 +62,10 @@ func WithLogger(l logger.Logger) Option { return func(e *Engine) { e.log = l } }
 // WithDryRun forces dry-run mode regardless of the config flag.
 func WithDryRun(dry bool) Option { return func(e *Engine) { e.dryRun = dry } }
 
+// WithRetryBackoff overrides the base retry backoff (delay for attempt N is
+// base*N). Primarily useful in tests to avoid real sleeps.
+func WithRetryBackoff(d time.Duration) Option { return func(e *Engine) { e.retryBackoff = d } }
+
 // New constructs an Engine. The config pointer is held by reference; do not
 // mutate it for the lifetime of the Engine.
 func New(cfg *config.Config, opts ...Option) *Engine {
@@ -79,6 +88,7 @@ func New(cfg *config.Config, opts ...Option) *Engine {
 		log:            logger.Nop(),
 		maxConcurrency: cfg.Settings.MaxConcurrency,
 		dryRun:         cfg.Settings.DryRun,
+		retryBackoff:   DefaultRetryBackoff,
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -101,16 +111,42 @@ func (e *Engine) RunFlow(ctx context.Context, flowName string) error {
 	if err != nil {
 		return err
 	}
+	flow := e.cfg.Flows[flowName]
 	e.log.Info("starting flow", "flow", flowName, "mode", string(p.Mode))
 
 	switch p.Mode {
 	case config.ModeStep:
-		return e.runStepPlan(ctx, p)
+		return e.runStepPlan(ctx, p, &flow)
 	case config.ModeDAG:
-		return e.runDAGPlan(ctx, p)
+		return e.runDAGPlan(ctx, p, &flow)
 	default:
 		return fmt.Errorf("flow %q: unknown mode %q", flowName, p.Mode)
 	}
+}
+
+// envelope is the resolved control envelope for a group's command execution.
+type envelope struct {
+	timeout time.Duration
+	retries int
+}
+
+// resolveEnvelope computes the effective timeout/retries for a wave. A step's
+// non-empty timeout / non-zero retries override the flow defaults; otherwise
+// the flow values apply. step may be nil (dag mode).
+func resolveEnvelope(flow *config.Flow, step *config.Step) envelope {
+	timeout, retries := flow.Timeout, flow.Retries
+	if step != nil {
+		if step.Timeout != "" {
+			timeout = step.Timeout
+		}
+		if step.Retries != 0 {
+			retries = step.Retries
+		}
+	}
+	// Durations are validated at config load, so a parse error here is
+	// impossible; treat any residual error as "no timeout".
+	d, _ := time.ParseDuration(timeout)
+	return envelope{timeout: d, retries: retries}
 }
 
 // runGroup decides whether and how to execute a group. The decision order is:
@@ -122,8 +158,9 @@ func (e *Engine) RunFlow(ctx context.Context, flowName string) error {
 //  5. otherwise  → invoke the runner and persist output (+ cache entry)
 //
 // Skipped or cache-hit groups still publish an output value so downstream
-// {{ output.X }} references resolve.
-func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string) error {
+// {{ output.X }} references resolve. The command run (only) is wrapped with the
+// envelope's per-attempt timeout and bounded retries.
+func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string, env envelope) error {
 	expanded := make([]string, len(group.Params))
 	for i, p := range group.Params {
 		expanded[i] = e.expander.Expand(p, baseline)
@@ -157,7 +194,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	}
 
 	e.log.Info("running group", "group", group.Name, "command", group.Command, "params", expanded)
-	out, err := e.runner.Run(ctx, group, expanded, e.cfg.Env)
+	out, err := e.execWithEnvelope(ctx, group, expanded, env)
 	if err != nil {
 		e.log.Error("group failed", "group", group.Name, "err", err.Error(), "output", out)
 		return err
@@ -166,6 +203,39 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	e.outputs.Set(group.Name, out)
 	e.cacheStore(group, expanded, out)
 	return nil
+}
+
+// execWithEnvelope runs the group's command, applying a per-attempt timeout and
+// retrying up to env.retries additional times on failure. Backoff between
+// attempts respects ctx cancellation.
+func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, params []string, env envelope) (string, error) {
+	attempts := 1 + env.retries
+	var (
+		out string
+		err error
+	)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		runCtx := ctx
+		cancel := context.CancelFunc(func() {})
+		if env.timeout > 0 {
+			runCtx, cancel = context.WithTimeout(ctx, env.timeout)
+		}
+		out, err = e.runner.Run(runCtx, group, params, e.cfg.Env)
+		cancel()
+		if err == nil {
+			return out, nil
+		}
+		if attempt < attempts {
+			e.log.Warn("group attempt failed; retrying",
+				"group", group.Name, "attempt", attempt, "of", attempts, "err", err.Error())
+			select {
+			case <-ctx.Done():
+				return out, ctx.Err()
+			case <-time.After(e.retryBackoff * time.Duration(attempt)):
+			}
+		}
+	}
+	return out, err
 }
 
 // cacheLookup returns the stored entry when caching is enabled for the group,

--- a/internal/engine/envelope_test.go
+++ b/internal/engine/envelope_test.go
@@ -1,0 +1,144 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// flakyRunner fails the first failUntil-1 attempts, then succeeds.
+type flakyRunner struct {
+	failUntil int32 // number of attempts that should fail
+	calls     int32
+	output    string
+}
+
+func (r *flakyRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (string, error) {
+	n := atomic.AddInt32(&r.calls, 1)
+	if n <= r.failUntil {
+		return "", errors.New("transient failure")
+	}
+	return r.output, nil
+}
+
+// blockingRunner blocks until ctx is done, then returns ctx.Err() — used to
+// exercise timeouts.
+type blockingRunner struct{ calls int32 }
+
+func (r *blockingRunner) Run(ctx context.Context, _ *config.Group, _ []string, _ map[string]string) (string, error) {
+	atomic.AddInt32(&r.calls, 1)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func TestResolveEnvelope(t *testing.T) {
+	t.Parallel()
+	flow := &config.Flow{Timeout: "5s", Retries: 2}
+
+	t.Run("flow defaults when step is nil (dag)", func(t *testing.T) {
+		env := resolveEnvelope(flow, nil)
+		assert.Equal(t, 5*time.Second, env.timeout)
+		assert.Equal(t, 2, env.retries)
+	})
+
+	t.Run("step overrides flow", func(t *testing.T) {
+		env := resolveEnvelope(flow, &config.Step{Timeout: "1s", Retries: 5})
+		assert.Equal(t, time.Second, env.timeout)
+		assert.Equal(t, 5, env.retries)
+	})
+
+	t.Run("step inherits flow when unset", func(t *testing.T) {
+		env := resolveEnvelope(flow, &config.Step{})
+		assert.Equal(t, 5*time.Second, env.timeout)
+		assert.Equal(t, 2, env.retries)
+	})
+
+	t.Run("no envelope at all", func(t *testing.T) {
+		env := resolveEnvelope(&config.Flow{}, &config.Step{})
+		assert.Equal(t, time.Duration(0), env.timeout)
+		assert.Equal(t, 0, env.retries)
+	})
+}
+
+func TestEngine_Retries_SucceedAfterFailures(t *testing.T) {
+	t.Parallel()
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "x"}}, [][]string{{"a"}})
+	withStepEnvelope(cfg, "", 2) // 2 retries → up to 3 attempts
+
+	r := &flakyRunner{failUntil: 2, output: "ok"}
+	e := New(cfg, WithRunner(r), WithRetryBackoff(time.Millisecond))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Equal(t, int32(3), atomic.LoadInt32(&r.calls), "should retry until the 3rd attempt succeeds")
+	v, _ := e.Outputs().Get("a")
+	assert.Equal(t, "ok", v)
+}
+
+func TestEngine_Retries_ExhaustedFails(t *testing.T) {
+	t.Parallel()
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "x"}}, [][]string{{"a"}})
+	withStepEnvelope(cfg, "", 1) // 1 retry → 2 attempts
+
+	r := &flakyRunner{failUntil: 99, output: "never"}
+	e := New(cfg, WithRunner(r), WithRetryBackoff(time.Millisecond))
+	err := e.RunFlow(context.Background(), "f")
+	require.Error(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&r.calls), "should attempt exactly 1+retries times")
+}
+
+func TestEngine_Timeout_Fires(t *testing.T) {
+	t.Parallel()
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "x"}}, [][]string{{"a"}})
+	withStepEnvelope(cfg, "20ms", 0)
+
+	r := &blockingRunner{}
+	e := New(cfg, WithRunner(r))
+	start := time.Now()
+	err := e.RunFlow(context.Background(), "f")
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second, "timeout should cut the run short")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&r.calls))
+}
+
+func TestEngine_Timeout_WithRetries_EachAttemptBounded(t *testing.T) {
+	t.Parallel()
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "x"}}, [][]string{{"a"}})
+	withStepEnvelope(cfg, "20ms", 2)
+
+	r := &blockingRunner{} // always times out
+	e := New(cfg, WithRunner(r), WithRetryBackoff(time.Millisecond))
+	err := e.RunFlow(context.Background(), "f")
+	require.Error(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&r.calls), "each of 1+retries attempts is timed out and retried")
+}
+
+func TestEngine_DAGFlow_UsesFlowEnvelope(t *testing.T) {
+	t.Parallel()
+	cfg := dagFlowCfg(t, []config.Group{{Name: "a", Command: "x"}}, []string{"a"})
+	f := cfg.Flows["f"]
+	f.Retries = 1
+	cfg.Flows["f"] = f
+
+	r := &flakyRunner{failUntil: 1, output: "ok"}
+	e := New(cfg, WithRunner(r), WithRetryBackoff(time.Millisecond))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&r.calls), "dag mode applies the flow-level retries")
+}
+
+// withStepEnvelope sets the timeout/retries envelope on the first step of the
+// test flow "f", in place.
+func withStepEnvelope(cfg *config.Config, timeout string, retries int) {
+	f := cfg.Flows["f"]
+	steps := make([]config.Step, len(f.Steps))
+	copy(steps, f.Steps)
+	steps[0].Timeout = timeout
+	steps[0].Retries = retries
+	f.Steps = steps
+	cfg.Flows["f"] = f
+}

--- a/internal/engine/envelope_test.go
+++ b/internal/engine/envelope_test.go
@@ -131,6 +131,46 @@ func TestEngine_DAGFlow_UsesFlowEnvelope(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&r.calls), "dag mode applies the flow-level retries")
 }
 
+// TestResolveEnvelope_FromFixture drives resolution from the real
+// config-envelope.yml fixture, pinning every edge (inherit, partial override,
+// full override, dag flow-level, no-envelope) against an actual file.
+func TestResolveEnvelope_FromFixture(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-envelope.yml")
+	require.NoError(t, err)
+
+	rel := cfg.Flows["release"]
+	t.Run("step inherits both flow defaults", func(t *testing.T) {
+		env := resolveEnvelope(&rel, &rel.Steps[0])
+		assert.Equal(t, time.Minute, env.timeout)
+		assert.Equal(t, 2, env.retries)
+	})
+	t.Run("step overrides timeout, retries 0 inherits flow", func(t *testing.T) {
+		env := resolveEnvelope(&rel, &rel.Steps[1])
+		assert.Equal(t, 10*time.Second, env.timeout)
+		assert.Equal(t, 2, env.retries, "retries: 0 means inherit, not override-to-zero")
+	})
+	t.Run("step overrides both", func(t *testing.T) {
+		env := resolveEnvelope(&rel, &rel.Steps[2])
+		assert.Equal(t, 5*time.Second, env.timeout)
+		assert.Equal(t, 5, env.retries)
+	})
+
+	t.Run("dag flow uses flow-level envelope", func(t *testing.T) {
+		dag := cfg.Flows["fast-dag"]
+		env := resolveEnvelope(&dag, nil)
+		assert.Equal(t, 30*time.Second, env.timeout)
+		assert.Equal(t, 1, env.retries)
+	})
+
+	t.Run("bare flow has no envelope", func(t *testing.T) {
+		bare := cfg.Flows["bare"]
+		env := resolveEnvelope(&bare, &bare.Steps[0])
+		assert.Equal(t, time.Duration(0), env.timeout)
+		assert.Equal(t, 0, env.retries)
+	})
+}
+
 // withStepEnvelope sets the timeout/retries envelope on the first step of the
 // test flow "f", in place.
 func withStepEnvelope(cfg *config.Config, timeout string, retries int) {

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -7,14 +7,17 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/plan"
 )
 
 // runDAGPlan runs the topological closure of the plan. A group starts as soon
 // as every group it references via {{ output.X }} has finished. The classical
 // Kahn-style ready queue is layered on top of errgroup so cancellation and
-// max-concurrency carry over without bespoke synchronization.
-func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan) error {
+// max-concurrency carry over without bespoke synchronization. Every group runs
+// under the flow-level envelope (dag mode has no per-step overrides).
+func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow) error {
+	env := resolveEnvelope(flow, nil)
 	// indeg tracks unresolved predecessors per group. It is mutated by the
 	// scheduler goroutine only.
 	indeg := make(map[string]int, len(p.Members))
@@ -44,7 +47,7 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan) error {
 			snapMu.RLock()
 			baseline := cloneSnapshot(snap)
 			snapMu.RUnlock()
-			if err := e.runGroup(gctx, &group, baseline); err != nil {
+			if err := e.runGroup(gctx, &group, baseline, env); err != nil {
 				return err
 			}
 			if v, ok := e.outputs.Get(name); ok {

--- a/internal/engine/scheduler_step.go
+++ b/internal/engine/scheduler_step.go
@@ -6,16 +6,19 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/plan"
 )
 
 // runStepPlan runs each wave of a step-mode plan in sequence. Within a wave,
 // groups run in parallel; a barrier separates consecutive waves. Each wave
-// sees a baseline snapshot of outputs from prior waves only.
-func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan) error {
+// sees a baseline snapshot of outputs from prior waves only, and runs under
+// the envelope resolved from its step (overriding the flow defaults).
+func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan, flow *config.Flow) error {
 	for waveIdx, wave := range p.Waves {
 		e.log.Info("step", "step", waveIdx+1, "groups", wave)
 
+		env := resolveEnvelope(flow, &flow.Steps[waveIdx])
 		baseline := e.outputs.Snapshot()
 		g, gctx := errgroup.WithContext(ctx)
 		if e.maxConcurrency > 0 {
@@ -23,7 +26,7 @@ func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan) error {
 		}
 		for _, name := range wave {
 			group := e.groups[name]
-			g.Go(func() error { return e.runGroup(gctx, &group, baseline) })
+			g.Go(func() error { return e.runGroup(gctx, &group, baseline, env) })
 		}
 		if err := g.Wait(); err != nil {
 			return fmt.Errorf("step %d: %w", waveIdx+1, err)


### PR DESCRIPTION
## Summary

Adds a control envelope — `timeout` and `retries` — to flows and steps. The engine wraps each group's **command run** in a per-attempt `context.WithTimeout` and a bounded retry loop with backoff. Groups stay atomic; the envelope is a property of how a pipeline runs them, so it lives on the step (step mode) and the flow (the default, and the only knob dag mode has).

```yaml
flows:
  release:
    timeout: 10m          # default per-group timeout for the whole flow
    retries: 1            # default retries on failure
    steps:
      - run: [build]
        timeout: 5m        # override for this wave
        retries: 2
      - run: [smoke]
        timeout: 30s
  release-dag:
    mode: dag
    timeout: 10m           # dag mode has no steps → flow-level envelope applies
    retries: 1
    run: [build, smoke]
```

## Semantics

| Field | Where | Meaning |
|---|---|---|
| `timeout` | flow and/or step | Go duration (`30s`, `5m`). Each command **attempt** is cancelled if it exceeds this. Empty = no timeout. |
| `retries` | flow and/or step | Additional attempts after the first failure. `0` = none. |

- **Resolution**: a step's non-empty `timeout` / non-zero `retries` override the flow defaults; otherwise the flow values apply. Dag mode uses the flow-level values (no steps).
- The envelope wraps **only the command run** — `require`/`skip-if` predicates and cache lookups are never retried or timed out.
- Each retry attempt gets a **fresh timeout**.
- Backoff between attempts is `base × attempt` (default base 250ms; `WithRetryBackoff` for tests) and **respects context cancellation** (Ctrl-C).
- A cache entry is written **only after a successful attempt**, so a failed/timed-out run never poisons the cache.

## Implementation

- `config`: `Flow.Timeout/Retries` + `Step.Timeout/Retries`; validation rejects unparseable durations and negative retries (`validateEnvelope`).
- `engine`: `resolveEnvelope(flow, step)` computes the effective envelope; `execWithEnvelope` runs the attempt loop with timeout + backoff; `runGroup` now takes the envelope. Both schedulers resolve and pass it (step scheduler per wave from `flow.Steps[i]`; dag scheduler once from the flow). `WithRetryBackoff` option added.
- No change to `Runner`/`OutputStore`/`Expander` interfaces.

## Tests

- `config`: valid flow+step envelope parsing, dag flow-level envelope, and four rejection cases (bad flow timeout, bad step timeout, negative flow retries, negative step retries).
- `engine`: `resolveEnvelope` table (flow default / step override / step inherit / none); retries succeed-after-N-failures (asserts exact attempt count); retries-exhausted-fails; timeout fires (bounded elapsed); timeout+retries (each of 1+retries attempts is timed out); dag mode uses the flow envelope. Fake `flakyRunner`/`blockingRunner`; `WithRetryBackoff(1ms)` keeps tests fast.
- Verified end-to-end with the built binary: a `sleep 5` group bounded to ~0.31s by a `300ms` timeout; a flaky group attempted 3× under `retries: 2`.

Coverage: engine 91.1%, config 93.3%; `go test -race ./...` clean; `golangci-lint run ./...` 0 issues.

## Docs

- CONFIG.md: new "Timeout and retries" subsection under flows.
- FAQ.md: "How do timeouts and retries work?" entry.

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] End-to-end timeout (bounded elapsed) and retries (attempt count) verified with the binary
- [ ] Exercise on a real flaky/long-running flow