### PR TITLE
feat: step-level when: conditionals

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -288,6 +288,28 @@ flows:
 Step mode is the right default: order is visible at a glance and barriers
 make behaviour predictable.
 
+A step may carry a `when:` predicate — a template that conditionally skips the
+whole step:
+
+```yaml
+flows:
+  release:
+    mode: step
+    steps:
+      - run: [test]
+      - run: [deploy]
+        when: '{{ eq (env "BRANCH") "main" }}'   # only deploy on main
+      - run: [notify]
+        when: '{{ contains "PASS" (output "test") }}'
+```
+
+`when` is rendered by the same template engine (it can use `output`, `env`,
+and sprig) and is **falsey** — and therefore skips the step — when it renders
+to `""`, `false`, `0`, `no`, or `off`. It is evaluated against the outputs of
+**earlier** steps plus the environment; referencing a same-step or later group
+is rejected at config-load. A skipped step's groups produce no output.
+`when:` applies to step mode only (dag mode has no steps).
+
 ### DAG mode
 
 DAG mode drops explicit steps. Groups schedule topologically from the data

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -239,6 +239,15 @@ the cache is written only on success, so a failed/timed-out run can't poison
 it. In dag mode there are no steps, so the flow-level values are the only
 envelope.
 
+### How does `when:` differ from a group's `skip-if`?
+
+`when:` is on a **step** and decides whether the whole wave runs; `skip-if:` is
+on a **group** and decides whether that one group runs. `when:` is a template
+predicate (uses `output`/`env`/sprig, falsey = skip) evaluated against earlier
+steps' outputs; `skip-if:` is a shell command (exit 0 = skip) run just before
+the group. Use `when:` for "should this phase happen at all?" and `skip-if:`
+for "is this group's work already done?". `when:` is step-mode only.
+
 ---
 
 ## Caching and gating

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,10 @@ type Step struct {
 	Run     []string `yaml:"run"`
 	Timeout string   `yaml:"timeout,omitempty"`
 	Retries int      `yaml:"retries,omitempty"`
+	// When is an optional template predicate. The step is skipped when it
+	// renders to a falsey value ("", "false", "0", "no", "off"). It is
+	// evaluated against the outputs of earlier steps plus the environment.
+	When string `yaml:"when,omitempty"`
 }
 
 // NewConfig parses YAML bytes into a Config and validates the schema.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -549,6 +549,51 @@ func TestNewConfig_RejectsMalformedTemplate(t *testing.T) {
 	}
 }
 
+func TestNewConfig_When(t *testing.T) {
+	t.Parallel()
+	t.Run("valid when with earlier-step ref parses", func(t *testing.T) {
+		cfg, err := NewConfig([]byte(`
+version: 2
+groups:
+  - {name: a, command: echo}
+  - {name: b, command: echo}
+flows:
+  f:
+    steps:
+      - run: [a]
+      - run: [b]
+        when: '{{ eq (output "a") "x" }}'
+`))
+		require.NoError(t, err)
+		assert.Equal(t, `{{ eq (output "a") "x" }}`, cfg.Flows["f"].Steps[1].When)
+	})
+
+	sameStep := `version: 2
+groups:
+  - {name: a, command: echo}
+flows:
+  f:
+    steps:
+      - run: [a]
+        when: '{{ output "a" }}'
+`
+	malformed := `version: 2
+groups:
+  - {name: a, command: echo}
+flows:
+  f:
+    steps:
+      - run: [a]
+        when: '{{ bogusfunc }}'
+`
+	for name, yaml := range map[string]string{"same-step ref": sameStep, "malformed": malformed} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewConfig([]byte(yaml))
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestExtractRefs(t *testing.T) {
 	t.Parallel()
 	g := &Group{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -594,6 +594,19 @@ flows:
 	}
 }
 
+func TestLoadConfig_WhenResource(t *testing.T) {
+	t.Parallel()
+	cfg, err := LoadConfig("./test-resources/config-when.yml")
+	require.NoError(t, err)
+	steps := cfg.Flows["ci"].Steps
+	require.Len(t, steps, 5)
+	assert.Empty(t, steps[0].When) // tests: no gate
+	assert.Equal(t, `{{ output "tests" | contains "PASS" }}`, steps[1].When)
+	assert.Equal(t, `{{ eq (env "DEPLOY") "true" }}`, steps[2].When)
+	assert.Equal(t, `{{ env "FORCE_ROLLBACK" }}`, steps[3].When)
+	assert.Empty(t, steps[4].When) // notify: always runs
+}
+
 func TestExtractRefs(t *testing.T) {
 	t.Parallel()
 	g := &Group{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -586,7 +586,22 @@ flows:
       - run: [a]
         when: '{{ bogusfunc }}'
 `
-	for name, yaml := range map[string]string{"same-step ref": sameStep, "malformed": malformed} {
+	// when references a group that exists but is not part of this flow.
+	notInFlow := `version: 2
+groups:
+  - {name: a, command: echo}
+  - {name: outsider, command: echo}
+flows:
+  f:
+    steps:
+      - run: [a]
+        when: '{{ output "outsider" }}'
+`
+	for name, yaml := range map[string]string{
+		"same-step ref":   sameStep,
+		"malformed":       malformed,
+		"ref not in flow": notInFlow,
+	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := NewConfig([]byte(yaml))
 			require.Error(t, err)

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -91,8 +91,34 @@ func (c *Config) checkStepRefs(flowName string, f *Flow, memberSet map[string]st
 				}
 			}
 		}
+		if err := c.checkWhenRefs(flowName, stepIdx, step.When, memberSet, seen); err != nil {
+			return err
+		}
 		for _, member := range step.Run {
 			seen[member] = struct{}{}
+		}
+	}
+	return nil
+}
+
+// checkWhenRefs validates that a step's `when` predicate only references groups
+// produced by earlier steps (the same rule as param/command references).
+func (c *Config) checkWhenRefs(flowName string, stepIdx int, when string, memberSet, seen map[string]struct{}) error {
+	if when == "" {
+		return nil
+	}
+	refs, err := template.Refs(when)
+	if err != nil {
+		return fmt.Errorf("flow %q step %d: when: %w", flowName, stepIdx+1, err)
+	}
+	for _, ref := range refs {
+		if _, ok := memberSet[ref]; !ok {
+			return fmt.Errorf("flow %q step %d: when references {{ output.%s }}, but %q is not part of this flow",
+				flowName, stepIdx+1, ref, ref)
+		}
+		if _, ok := seen[ref]; !ok {
+			return fmt.Errorf("flow %q step %d: when references {{ output.%s }}, but %q is not produced by an earlier step",
+				flowName, stepIdx+1, ref, ref)
 		}
 	}
 	return nil

--- a/internal/config/test-resources/config-when.yml
+++ b/internal/config/test-resources/config-when.yml
@@ -1,0 +1,33 @@
+---
+# Exercises step-level `when:` conditionals across the documented forms:
+#   - a predicate over a prior step's output ({{ output "tests" | contains ... }})
+#   - a predicate over the environment ({{ eq (env "DEPLOY") "true" }})
+#   - a falsey predicate that skips its step ({{ env "FORCE_ROLLBACK" }} → empty)
+#   - a step with no `when:` that always runs
+version: 2
+
+env:
+  DEPLOY: "true"
+
+groups:
+  - { name: tests, command: echo, params: ["PASS"] }
+  - { name: build, command: echo, params: ["built"] }
+  - { name: deploy, command: echo, params: ["deploying"] }
+  - { name: rollback, command: echo, params: ["rolling back"] }
+  - { name: notify, command: echo, params: ["notifying"] }
+
+default: ci
+
+flows:
+  ci:
+    description: "Gate steps on prior output and environment"
+    mode: step
+    steps:
+      - run: [tests]
+      - run: [build]
+        when: '{{ output "tests" | contains "PASS" }}' # runs: tests printed PASS
+      - run: [deploy]
+        when: '{{ eq (env "DEPLOY") "true" }}' # runs: DEPLOY=true
+      - run: [rollback]
+        when: '{{ env "FORCE_ROLLBACK" }}' # skipped: unset → empty → falsey
+      - run: [notify] # always runs (no when)

--- a/internal/config/test-resources/config-when.yml
+++ b/internal/config/test-resources/config-when.yml
@@ -8,6 +8,7 @@ version: 2
 
 env:
   DEPLOY: "true"
+  COUNT: "3"
 
 groups:
   - { name: tests, command: echo, params: ["PASS"] }
@@ -15,6 +16,11 @@ groups:
   - { name: deploy, command: echo, params: ["deploying"] }
   - { name: rollback, command: echo, params: ["rolling back"] }
   - { name: notify, command: echo, params: ["notifying"] }
+  - { name: e-and, command: echo, params: ["and"] }
+  - { name: e-or, command: echo, params: ["or"] }
+  - { name: e-not, command: echo, params: ["not"] }
+  - { name: e-num, command: echo, params: ["num"] }
+  - { name: e-skip, command: echo, params: ["skip"] }
 
 default: ci
 
@@ -31,3 +37,18 @@ flows:
       - run: [rollback]
         when: '{{ env "FORCE_ROLLBACK" }}' # skipped: unset → empty → falsey
       - run: [notify] # always runs (no when)
+
+  edges:
+    description: "Boolean, numeric, and negation predicate edge cases"
+    mode: step
+    steps:
+      - run: [e-and]
+        when: '{{ and (eq (env "DEPLOY") "true") true }}' # runs
+      - run: [e-or]
+        when: '{{ or false (eq (env "DEPLOY") "true") }}' # runs
+      - run: [e-not]
+        when: '{{ not (env "FORCE") }}' # runs: FORCE unset → empty → not → true
+      - run: [e-num]
+        when: '{{ gt (atoi (env "COUNT")) 2 }}' # runs: 3 > 2
+      - run: [e-skip]
+        when: '{{ eq (env "DEPLOY") "no" }}' # skipped: DEPLOY is "true"

--- a/internal/engine/scheduler_step.go
+++ b/internal/engine/scheduler_step.go
@@ -3,12 +3,29 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/plan"
+	"github.com/quike/keepup/internal/template"
 )
+
+// evalWhen renders a step's `when` predicate and reports whether the step
+// should run. The result is falsey (skip) for "", "false", "0", "no", "off".
+func (e *Engine) evalWhen(expr string, baseline map[string]string) (bool, error) {
+	out, err := e.expander.Expand(expr, template.Data{Outputs: baseline, Env: e.cfg.Env})
+	if err != nil {
+		return false, err
+	}
+	switch strings.TrimSpace(strings.ToLower(out)) {
+	case "", "false", "0", "no", "off": //nolint:goconst // falsey-literal set
+		return false, nil
+	default:
+		return true, nil
+	}
+}
 
 // runStepPlan runs each wave of a step-mode plan in sequence. Within a wave,
 // groups run in parallel; a barrier separates consecutive waves. Each wave
@@ -16,10 +33,22 @@ import (
 // the envelope resolved from its step (overriding the flow defaults).
 func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan, flow *config.Flow) error {
 	for waveIdx, wave := range p.Waves {
+		step := &flow.Steps[waveIdx]
 		e.log.Info("step", "step", waveIdx+1, "groups", wave)
 
-		env := resolveEnvelope(flow, &flow.Steps[waveIdx])
 		baseline := e.outputs.Snapshot()
+		if step.When != "" {
+			run, err := e.evalWhen(step.When, baseline)
+			if err != nil {
+				return fmt.Errorf("step %d: when: %w", waveIdx+1, err)
+			}
+			if !run {
+				e.log.Info("step skipped", "step", waveIdx+1, "reason", "when", "predicate", step.When)
+				continue
+			}
+		}
+
+		env := resolveEnvelope(flow, step)
 		g, gctx := errgroup.WithContext(ctx)
 		if e.maxConcurrency > 0 {
 			g.SetLimit(e.maxConcurrency)

--- a/internal/engine/when_test.go
+++ b/internal/engine/when_test.go
@@ -88,6 +88,19 @@ func TestEngine_When_FromFixture(t *testing.T) {
 	assert.Equal(t, []string{"tests:PASS", "build:built", "deploy:deploying", "notify:notifying"}, r.calls)
 }
 
+func TestEngine_When_EdgesFlow(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-when.yml")
+	require.NoError(t, err)
+
+	r := &fakeRunner{}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "edges"))
+
+	// and/or/not/num all evaluate truthy; e-skip is gated false.
+	assert.Equal(t, []string{"e-and:and", "e-or:or", "e-not:not", "e-num:num"}, r.calls)
+}
+
 func TestEngine_When_BadTemplateErrors(t *testing.T) {
 	t.Parallel()
 	e := New(stepFlowWithWhen(`{{ fail "boom" }}`), WithRunner(&fakeRunner{}))

--- a/internal/engine/when_test.go
+++ b/internal/engine/when_test.go
@@ -74,6 +74,20 @@ func TestEngine_When_ReferencesEarlierOutput(t *testing.T) {
 	assert.Equal(t, []string{"producer:", "gated:"}, r.calls)
 }
 
+func TestEngine_When_FromFixture(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-when.yml")
+	require.NoError(t, err)
+
+	r := &fakeRunner{outputs: map[string]string{"tests": "PASS\n"}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	// build runs (tests PASS), deploy runs (DEPLOY=true), rollback is skipped
+	// (FORCE_ROLLBACK unset), notify always runs.
+	assert.Equal(t, []string{"tests:PASS", "build:built", "deploy:deploying", "notify:notifying"}, r.calls)
+}
+
 func TestEngine_When_BadTemplateErrors(t *testing.T) {
 	t.Parallel()
 	e := New(stepFlowWithWhen(`{{ fail "boom" }}`), WithRunner(&fakeRunner{}))

--- a/internal/engine/when_test.go
+++ b/internal/engine/when_test.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// stepFlowWithWhen builds a one-step flow whose single group is "a", with the
+// given `when` predicate on that step.
+func stepFlowWithWhen(when string) *config.Config {
+	return &config.Config{
+		Version: config.SchemaVersion,
+		Groups:  []config.Group{{Name: "a", Command: "echo"}},
+		Flows: map[string]config.Flow{
+			"f": {Mode: config.ModeStep, Steps: []config.Step{{Run: []string{"a"}, When: when}}},
+		},
+	}
+}
+
+func TestEngine_When(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		when    string
+		wantRun bool
+	}{
+		{"literal true runs", "true", true},
+		{"literal false skips", "false", false},
+		{"empty render skips", `{{ env "MISSING" }}`, false},
+		{"zero skips", "0", false},
+		{"no/off skip", "off", false},
+		{"non-empty text runs", "yes", true},
+		{"sprig predicate true", `{{ eq "x" "x" }}`, true},
+		{"sprig predicate false", `{{ eq "x" "y" }}`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeRunner{outputs: map[string]string{"a": "ran"}}
+			e := New(stepFlowWithWhen(tc.when), WithRunner(r))
+			require.NoError(t, e.RunFlow(context.Background(), "f"))
+			if tc.wantRun {
+				assert.Equal(t, []string{"a:"}, r.calls)
+			} else {
+				assert.Empty(t, r.calls, "step should have been skipped")
+			}
+		})
+	}
+}
+
+func TestEngine_When_ReferencesEarlierOutput(t *testing.T) {
+	t.Parallel()
+	// gate runs only if the producer's output contains "GO".
+	cfg := &config.Config{
+		Version: config.SchemaVersion,
+		Groups: []config.Group{
+			{Name: "producer", Command: "echo"},
+			{Name: "gated", Command: "echo"},
+		},
+		Flows: map[string]config.Flow{
+			"f": {Mode: config.ModeStep, Steps: []config.Step{
+				{Run: []string{"producer"}},
+				{Run: []string{"gated"}, When: `{{ contains "GO" (output "producer") }}`},
+			}},
+		},
+	}
+	r := &fakeRunner{outputs: map[string]string{"producer": "GO\n", "gated": "done"}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Equal(t, []string{"producer:", "gated:"}, r.calls)
+}
+
+func TestEngine_When_BadTemplateErrors(t *testing.T) {
+	t.Parallel()
+	e := New(stepFlowWithWhen(`{{ fail "boom" }}`), WithRunner(&fakeRunner{}))
+	err := e.RunFlow(context.Background(), "f")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "when")
+}


### PR DESCRIPTION
## Summary

Adds `when:` to a step — a template predicate that conditionally skips the whole wave. This is Phase 2 of the templating work, built on the Go-template + sprig engine.

```yaml
flows:
  release:
    mode: step
    steps:
      - run: [test]
      - run: [deploy]
        when: '{{ eq (env "BRANCH") "main" }}'
      - run: [notify]
        when: '{{ contains "PASS" (output "test") }}'
```

## Semantics

- Rendered by the same engine (`output`, `env`, sprig all available).
- **Falsey → skip the step**: `""`, `false`, `0`, `no`, `off` (case-insensitive, trimmed). Anything else runs.
- Evaluated against the outputs of **earlier** steps plus the environment. Referencing a same-step or later group is rejected at config-load (same rule as param/command refs).
- A render error fails the flow with a clear `step N: when:` message.
- Step mode only (dag mode has no steps).

## Implementation

- `config.Step.When` field; `checkWhenRefs` validates `when` references against earlier steps and rejects malformed templates at load.
- `engine.evalWhen` renders the predicate and applies the falsey rule; `runStepPlan` skips the wave (logged) when it's false.

## Tests

- `engine`: truthy/falsey table (`true`/`false`/empty-render/`0`/`off`/text/sprig-eq both ways), a `when` that references an earlier step's output, and a render-error case.
- `config`: valid `when` with earlier-step ref parses; same-step ref rejected; malformed template rejected.
- Smoke-tested with the binary: `deploy` ran on `BRANCH=main`, a `release`-gated step was skipped.

`go test -race ./...` clean; `golangci-lint run ./...` 0 issues.

## Docs

- CONFIG.md: `when:` subsection under step mode.
- FAQ.md: "How does `when:` differ from a group's `skip-if`?"

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] End-to-end skip/run verified with the binary