### PR TITLE
feat: keepup init scaffold command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ shell unless you ask for it), and incremental re-runs via content-based caching.
 ## Quick start
 
 ```sh
+keepup init           # scaffold a starter keepup.yml
 keepup run            # run the default flow
 keepup run ci         # run a named flow
 keepup watch dev      # re-run on file changes

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// starterConfig is the v2 scaffold written by `keepup init`. It is validated
+// against the parser in a test, so it always loads.
+const starterConfig = `version: 2
+
+settings:
+  logging:
+    level: info
+    pretty: true
+
+groups:
+  - name: hello
+    description: "Print a greeting"
+    command: echo
+    params: ["hello from keepup"]
+
+  - name: world
+    description: "Build on the previous group's output"
+    command: echo
+    params: ['{{ output "hello" }} — world']
+
+default: greet
+
+flows:
+  greet:
+    description: "Say hello, then consume its output"
+    mode: step
+    steps:
+      - run: [hello]
+      - run: [world]
+`
+
+func newInitCmd(stdout io.Writer) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init [path]",
+		Short: "Write a starter keepup.yml to get going quickly",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			path := "keepup.yml"
+			if len(args) == 1 {
+				path = args[0]
+			}
+			if _, err := os.Stat(path); err == nil && !force {
+				return fmt.Errorf("%s already exists; pass --force to overwrite", path)
+			}
+			if dir := filepath.Dir(path); dir != "." && dir != "" {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					return fmt.Errorf("create %s: %w", dir, err)
+				}
+			}
+			if err := os.WriteFile(filepath.Clean(path), []byte(starterConfig), 0o600); err != nil {
+				return fmt.Errorf("write %s: %w", path, err)
+			}
+			fmt.Fprintf(stdout, "wrote %s — run `keepup run` to try it\n", path)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite an existing file")
+	return cmd
+}
+
+// starterIsValid is a guard used by tests to ensure the scaffold always parses.
+func starterIsValid() error {
+	_, err := config.NewConfig([]byte(starterConfig))
+	return err
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,14 +43,26 @@ flows:
 `
 
 func newInitCmd(stdout io.Writer) *cobra.Command {
-	var force bool
+	var (
+		force  bool
+		global bool
+	)
 	cmd := &cobra.Command{
 		Use:   "init [path]",
 		Short: "Write a starter keepup.yml to get going quickly",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			path := "keepup.yml"
-			if len(args) == 1 {
+			switch {
+			case global && len(args) == 1:
+				return fmt.Errorf("--global and an explicit path are mutually exclusive")
+			case global:
+				p, err := defaultConfigPath()
+				if err != nil {
+					return err
+				}
+				path = p
+			case len(args) == 1:
 				path = args[0]
 			}
 			if _, err := os.Stat(path); err == nil && !force {
@@ -69,6 +81,7 @@ func newInitCmd(stdout io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite an existing file")
+	cmd.Flags().BoolVarP(&global, "global", "g", false, "Write to the default config path (~/.config/keepup/keepup.yml)")
 	return cmd
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -61,6 +61,29 @@ func TestInitCmd(t *testing.T) {
 	})
 }
 
+func TestInitCmd_Global(t *testing.T) {
+	t.Run("writes to the default config path", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", "--global"})
+		require.NoError(t, cmd.Execute())
+		assert.FileExists(t, filepath.Join(home, ".config", "keepup", "keepup.yml"))
+	})
+
+	t.Run("--global with explicit path is rejected", func(t *testing.T) {
+		t.Parallel()
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", "--global", "x.yml"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+}
+
 func TestInitCmd_GeneratedConfigIsValid(t *testing.T) {
 	t.Parallel()
 	// The scaffold must always parse + validate, and running it must work.

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCmd(t *testing.T) {
+	t.Run("writes starter to given path", func(t *testing.T) {
+		t.Parallel()
+		dst := filepath.Join(t.TempDir(), "keepup.yml")
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", dst})
+		require.NoError(t, cmd.Execute())
+
+		assert.Contains(t, out.String(), "wrote "+dst)
+		data, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "version: 2")
+		assert.Contains(t, string(data), "flows:")
+	})
+
+	t.Run("refuses to overwrite without --force", func(t *testing.T) {
+		t.Parallel()
+		dst := filepath.Join(t.TempDir(), "keepup.yml")
+		require.NoError(t, os.WriteFile(dst, []byte("existing"), 0o600))
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", dst})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("--force overwrites", func(t *testing.T) {
+		t.Parallel()
+		dst := filepath.Join(t.TempDir(), "keepup.yml")
+		require.NoError(t, os.WriteFile(dst, []byte("existing"), 0o600))
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", dst, "--force"})
+		require.NoError(t, cmd.Execute())
+		data, _ := os.ReadFile(dst)
+		assert.Contains(t, string(data), "version: 2")
+	})
+
+	t.Run("creates parent directories", func(t *testing.T) {
+		t.Parallel()
+		dst := filepath.Join(t.TempDir(), "nested", "dir", "keepup.yml")
+		var out bytes.Buffer
+		cmd := newRootCmd(&out, &out)
+		cmd.SetArgs([]string{"init", dst})
+		require.NoError(t, cmd.Execute())
+		assert.FileExists(t, dst)
+	})
+}
+
+func TestInitCmd_GeneratedConfigIsValid(t *testing.T) {
+	t.Parallel()
+	// The scaffold must always parse + validate, and running it must work.
+	require.NoError(t, starterIsValid())
+
+	dst := filepath.Join(t.TempDir(), "keepup.yml")
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"init", dst})
+	require.NoError(t, cmd.Execute())
+
+	val := newRootCmd(&out, &out)
+	val.SetArgs([]string{"validate", "--config", dst})
+	require.NoError(t, val.Execute())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root.PersistentFlags().BoolVarP(&opts.dryRun, "dry-run", "d", false, "Dry run mode (no commands are executed)")
 	root.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "Verbose output")
 
+	root.AddCommand(newInitCmd(stdout))
 	root.AddCommand(newRunCmd(opts))
 	root.AddCommand(newWatchCmd(opts, stdout))
 	root.AddCommand(newListCmd(opts, stdout))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -393,7 +393,7 @@ at an existing flow; otherwise the file is rejected at parse time.
 ## CLI subcommands
 
 ```sh
-keepup init [path]           # write a starter keepup.yml (--force to overwrite)
+keepup init [path]           # write a starter keepup.yml (--global for ~/.config, --force to overwrite)
 keepup run [flow]            # run the named flow, or the default
 keepup watch [flow]          # re-run a flow when its cache.reads inputs change
 keepup list                  # show declared flows + descriptions

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -393,6 +393,7 @@ at an existing flow; otherwise the file is rejected at parse time.
 ## CLI subcommands
 
 ```sh
+keepup init [path]           # write a starter keepup.yml (--force to overwrite)
 keepup run [flow]            # run the named flow, or the default
 keepup watch [flow]          # re-run a flow when its cache.reads inputs change
 keepup list                  # show declared flows + descriptions

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -345,6 +345,22 @@ watch started are the one gap — restart watch if you add a whole new source ro
 
 ## CLI
 
+### How do I get started quickly?
+
+`keepup init` writes a small, valid starter `keepup.yml`:
+
+```sh
+keepup init            # → ./keepup.yml (project-local)
+keepup init --global   # → ~/.config/keepup/keepup.yml (the default path)
+keepup init --force    # overwrite an existing file
+```
+
+`./keepup.yml` is convenient for a repo you'll run with `keepup run --config keepup.yml`
+(or from that directory). `--global` writes to the path keepup reads when no
+`--config` is given, so afterward a bare `keepup run` just works. `--global`
+and an explicit path are mutually exclusive. The scaffold defines two groups
+and a step flow that demonstrates output piping, and it's guaranteed to parse.
+
 ### What replaces the old `--group <name>` flag?
 
 Declare a flow that runs just that group:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,6 +51,7 @@ flows:
 ## CLI cheatsheet
 
 ```sh
+keepup init               # scaffold a starter keepup.yml
 keepup run                # run the default flow
 keepup run <flow>         # run a specific flow
 keepup watch [flow]       # re-run a flow when its cache.reads inputs change

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,7 +51,7 @@ flows:
 ## CLI cheatsheet
 
 ```sh
-keepup init               # scaffold a starter keepup.yml
+keepup init               # scaffold a starter keepup.yml (--global → ~/.config/keepup)
 keepup run                # run the default flow
 keepup run <flow>         # run a specific flow
 keepup watch [flow]       # re-run a flow when its cache.reads inputs change


### PR DESCRIPTION
## Summary

Adds `keepup init [path]` — writes a small, valid v2 starter config so new users get a working file in one command.

```sh
keepup init                 # → ./keepup.yml (project-local)
keepup init --global        # → ~/.config/keepup/keepup.yml (the default path)
keepup init path/to.yml     # custom path (parent dirs created)
keepup init --force         # overwrite an existing file
```

The scaffold defines two groups, a step-mode flow, and demonstrates output piping (`{{ output "hello" }}`). It refuses to overwrite an existing file unless `--force`, and creates parent directories as needed.

### `--global`

Since keepup reads `~/.config/keepup/keepup.yml` when no `--config` is given, `keepup init --global` (`-g`) writes the scaffold straight there (via the same `defaultConfigPath()` the CLI uses) — so afterward a bare `keepup run` just works. `--global` and an explicit path are mutually exclusive.

## Tests

- Writes to a given path; refuses overwrite without `--force`; `--force` overwrites; creates parent dirs.
- `--global` writes to the default config path (verified with `$HOME` swapped to a temp dir); `--global` + explicit path is rejected.
- `starterIsValid()` guard + an end-to-end test that `init`s then `validate`s the generated file — guaranteeing the scaffold always parses.

`go test -race ./...` clean; `golangci-lint run ./...` 0 issues. Smoke-tested: `init` then `run --config keepup.yml` prints `hello from keepup — world` (piping works).

## Docs

- README quick-start, CONFIG.md subcommand list, USAGE.md cheatsheet, and a FAQ entry ("How do I get started quickly?") covering both `init` and `init --global`.

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] Scaffold runs end-to-end
- [x] `--global` writes to the default path