### PR TITLE
feat: JSON event stream via run --events

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ shell unless you ask for it), and incremental re-runs via content-based caching.
 | **Safe execution**       | Commands run as real argv by default (no shell injection); opt into a shell per group with `shell:`.                        |
 | **Env layering**         | Global `env:` plus per-group overrides, merged over the process environment.                                                |
 | **Discoverability**      | `keepup list`, `keepup validate`, and `keepup graph` (Mermaid diagram of the data DAG).                                     |
+| **JSON events**          | `keepup run --events` emits a newline-delimited JSON stream (`group.end` with status + durationMs) for CI tooling.          |
 | **Migration**            | `keepup migrate` converts legacy v1 configs to v2 and validates the result.                                                 |
 
 ## Quick start

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newRunCmd(opts *runtimeOpts) *cobra.Command {
+	var eventsPath string
 	cmd := &cobra.Command{
 		Use:   "run [flow]",
 		Short: "Execute a flow (uses the configured default when no flow is given)",
@@ -98,16 +99,39 @@ func newRunCmd(opts *runtimeOpts) *cobra.Command {
 			if len(args) == 1 {
 				flowName = args[0]
 			}
-			e := engine.New(opts.cfg,
+			engineOpts := []engine.Option{
 				engine.WithLogger(opts.log),
 				engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),
 				engine.WithNoCache(opts.noCache),
-			)
+			}
+			if eventsPath != "" {
+				w, closeFn, err := openEventsWriter(eventsPath, cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
+				defer closeFn()
+				engineOpts = append(engineOpts, engine.WithEmitter(engine.NewJSONEmitter(w)))
+			}
+			e := engine.New(opts.cfg, engineOpts...)
 			return e.RunFlow(cmd.Context(), flowName)
 		},
 	}
 	cmd.Flags().BoolVar(&opts.noCache, "no-cache", false, "Ignore cached results; run every group")
+	cmd.Flags().StringVar(&eventsPath, "events", "", "Write a JSON event stream to this file ('-' for stdout)")
 	return cmd
+}
+
+// openEventsWriter resolves the --events target: "-" means stdout, otherwise a
+// file (truncated). The returned closer is a no-op for stdout.
+func openEventsWriter(path string, stdout io.Writer) (io.Writer, func(), error) {
+	if path == "-" {
+		return stdout, func() {}, nil
+	}
+	f, err := os.Create(filepath.Clean(path))
+	if err != nil {
+		return nil, nil, fmt.Errorf("open events file %q: %w", path, err)
+	}
+	return f, func() { _ = f.Close() }, nil
 }
 
 func newListCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -82,6 +82,30 @@ func TestRunCmd_NamedFlow(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 }
 
+func TestRunCmd_EventsToStdout(t *testing.T) {
+	t.Parallel()
+	cfgPath := writeTempConfig(t, minimalCfg)
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"run", "f", "--config", cfgPath, "--dry-run", "--events", "-"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), `"event":"flow.start"`)
+	assert.Contains(t, out.String(), `"event":"group.end"`)
+}
+
+func TestRunCmd_EventsToFile(t *testing.T) {
+	t.Parallel()
+	cfgPath := writeTempConfig(t, minimalCfg)
+	evPath := filepath.Join(t.TempDir(), "events.jsonl")
+	var out bytes.Buffer
+	cmd := newRootCmd(&out, &out)
+	cmd.SetArgs([]string{"run", "f", "--config", cfgPath, "--dry-run", "--events", evPath})
+	require.NoError(t, cmd.Execute())
+	data, err := os.ReadFile(evPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"event":"flow.end"`)
+}
+
 func TestListCmd_Flows(t *testing.T) {
 	t.Parallel()
 	cfgPath := writeTempConfig(t, minimalCfg)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -423,6 +423,7 @@ Global flags:
 | Flag         | Purpose                                                            |
 | ------------ | ------------------------------------------------------------------ |
 | `--no-cache` | Ignore cached results and run every group (entries still refresh). |
+| `--events <path>` | Write a newline-delimited JSON event stream (`flow.start`/`group.end`/… with status + durationMs) to a file, or `-` for stdout. |
 
 `keepup graph <flow>` prints a Mermaid `graph TD` showing the data DAG that
 emerges from the `{{ output.X }}` references — useful as a sanity check

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -376,18 +376,65 @@ Then `keepup run quick`. This is more discoverable (`keepup list` shows it),
 composable (you can build it up over time), and consistent with how every
 other invocation works.
 
-### Can I get machine-readable run output for CI?
+### What is the JSON event stream and what can I use it for?
 
-Yes — `keepup run --events <path>` writes a newline-delimited JSON event
-stream: `flow.start`, `group.start`, `group.end` (with `status` of
-ok/failed/skipped/cache-hit/dry-run and `durationMs`), and `flow.end`. Use a
-file path, or `-` to write to stdout. It's independent of the human/JSON
-logging (`settings.logging`) — events are for tooling, logs are for people.
+When keepup runs a flow it prints human logs. With `--events` it *also* emits a
+second, separate stream: **one JSON object per line, one line per thing that
+happens.** That's the whole idea.
 
 ```sh
 keepup run ci --events run.jsonl
-keepup run ci --events -          # to stdout
 ```
+
+`run.jsonl` then contains:
+
+```json
+{"event":"flow.start","flow":"ci","mode":"step","time":"..."}
+{"event":"group.start","group":"tests","time":"..."}
+{"event":"group.end","group":"tests","status":"ok","durationMs":1240,"time":"..."}
+{"event":"group.start","group":"deploy","time":"..."}
+{"event":"group.end","group":"deploy","status":"skipped","durationMs":0,"time":"..."}
+{"event":"flow.end","flow":"ci","status":"ok","durationMs":1310,"time":"..."}
+```
+
+Each line tells you **what happened** (`event`), **to which group**, **how it
+ended** (`status`: `ok` / `failed` / `skipped` / `cache-hit` / `dry-run`), and
+**how long it took** (`durationMs`).
+
+**Why separate from logs?** Logs are for humans (prose, colors, wording that may
+change). Events are for machines (fixed fields, stable shape). Parsing human
+logs is fragile; the event stream is a contract you can build on.
+
+**What it's good for:**
+
+| Use | How |
+|-----|-----|
+| CI dashboards / timing | Read `durationMs` per group to find the bottleneck and track it over time. |
+| Notifications | Watch for `flow.end` with `status:"failed"` and alert. |
+| Cache effectiveness | Count `cache-hit` vs `ok` to see how much work was skipped. |
+| Audit / history | Append the `.jsonl` files to keep a record of every run. |
+| Custom tooling | Anything that needs to react to a run without scraping logs. |
+
+**Example one-liners** (using `jq`, but any language parses JSON lines):
+
+```sh
+# Did the flow fail?
+keepup run ci --events - | jq -e 'select(.event=="flow.end" and .status=="failed")' && echo ALERT
+
+# Slowest group
+keepup run ci --events - | jq 'select(.event=="group.end")' | jq -s 'max_by(.durationMs)'
+
+# How many cache hits?
+keepup run ci --events - | jq 'select(.status=="cache-hit")' | wc -l
+```
+
+It's independent of the human/JSON logging (`settings.logging`) — logs are for
+people, events are for tooling. If you only run keepup by hand in a terminal you
+don't need it; it shines when something *else* watches your runs.
+
+Note: use `--events run.jsonl` (a file) or `--events -` (stdout). On stdout the
+events mix with your commands' own output, so a file is usually cleaner for real
+use.
 
 ### How do I see what flows and groups are available?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -376,6 +376,19 @@ Then `keepup run quick`. This is more discoverable (`keepup list` shows it),
 composable (you can build it up over time), and consistent with how every
 other invocation works.
 
+### Can I get machine-readable run output for CI?
+
+Yes — `keepup run --events <path>` writes a newline-delimited JSON event
+stream: `flow.start`, `group.start`, `group.end` (with `status` of
+ok/failed/skipped/cache-hit/dry-run and `durationMs`), and `flow.end`. Use a
+file path, or `-` to write to stdout. It's independent of the human/JSON
+logging (`settings.logging`) — events are for tooling, logs are for people.
+
+```sh
+keepup run ci --events run.jsonl
+keepup run ci --events -          # to stdout
+```
+
 ### How do I see what flows and groups are available?
 
 ```sh

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,6 +25,7 @@ type Engine struct {
 	outputs        OutputStore
 	expander       template.Expander
 	cache          cache.Store
+	emitter        Emitter
 	log            logger.Logger
 	maxConcurrency int
 	dryRun         bool
@@ -63,6 +64,9 @@ func WithLogger(l logger.Logger) Option { return func(e *Engine) { e.log = l } }
 // WithDryRun forces dry-run mode regardless of the config flag.
 func WithDryRun(dry bool) Option { return func(e *Engine) { e.dryRun = dry } }
 
+// WithEmitter sets the structured event emitter (default: discard).
+func WithEmitter(em Emitter) Option { return func(e *Engine) { e.emitter = em } }
+
 // WithRetryBackoff overrides the base retry backoff (delay for attempt N is
 // base*N). Primarily useful in tests to avoid real sleeps.
 func WithRetryBackoff(d time.Duration) Option { return func(e *Engine) { e.retryBackoff = d } }
@@ -86,6 +90,7 @@ func New(cfg *config.Config, opts ...Option) *Engine {
 		outputs:        NewMemoryOutputStore(),
 		expander:       template.NewExpander(),
 		cache:          cache.NewFileStore(cacheDir),
+		emitter:        nopEmitter{},
 		log:            logger.Nop(),
 		maxConcurrency: cfg.Settings.MaxConcurrency,
 		dryRun:         cfg.Settings.DryRun,
@@ -114,15 +119,26 @@ func (e *Engine) RunFlow(ctx context.Context, flowName string) error {
 	}
 	flow := e.cfg.Flows[flowName]
 	e.log.Info("starting flow", "flow", flowName, "mode", string(p.Mode))
+	e.emitter.Emit(Event{Event: EventFlowStart, Flow: flowName, Mode: string(p.Mode)})
 
+	start := time.Now()
 	switch p.Mode {
 	case config.ModeStep:
-		return e.runStepPlan(ctx, p, &flow)
+		err = e.runStepPlan(ctx, p, &flow)
 	case config.ModeDAG:
-		return e.runDAGPlan(ctx, p, &flow)
+		err = e.runDAGPlan(ctx, p, &flow)
 	default:
-		return fmt.Errorf("flow %q: unknown mode %q", flowName, p.Mode)
+		err = fmt.Errorf("flow %q: unknown mode %q", flowName, p.Mode)
 	}
+	status := StatusOK
+	if err != nil {
+		status = StatusFailed
+	}
+	e.emitter.Emit(Event{
+		Event: EventFlowEnd, Flow: flowName, Status: status,
+		DurationMS: msSince(start), Err: errString(err),
+	})
+	return err
 }
 
 // envelope is the resolved control envelope for a group's command execution.
@@ -161,7 +177,20 @@ func resolveEnvelope(flow *config.Flow, step *config.Step) envelope {
 // Skipped or cache-hit groups still publish an output value so downstream
 // {{ output.X }} references resolve. The command run (only) is wrapped with the
 // envelope's per-attempt timeout and bounded retries.
-func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string, env envelope) error {
+func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string, env envelope) (err error) {
+	start := time.Now()
+	e.emitter.Emit(Event{Event: EventGroupStart, Group: group.Name})
+	status := StatusOK
+	defer func() {
+		if err != nil {
+			status = StatusFailed
+		}
+		e.emitter.Emit(Event{
+			Event: EventGroupEnd, Group: group.Name, Status: status,
+			DurationMS: msSince(start), Err: errString(err),
+		})
+	}()
+
 	data := template.Data{Outputs: baseline, Env: e.cfg.Env}
 
 	// Expand the command and every param against the available outputs/env.
@@ -185,6 +214,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	if e.dryRun {
 		e.log.Info("[dry-run] would run",
 			"group", g.Name, "command", g.Command, "params", expanded, "shell", g.UseShell())
+		status = StatusDryRun
 		return nil
 	}
 
@@ -199,6 +229,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 			out := e.cachedOutput(&g)
 			e.outputs.Set(g.Name, out)
 			e.log.Info("group skipped", "group", g.Name, "reason", "skip-if", "predicate", g.SkipIf)
+			status = StatusSkipped
 			return nil
 		}
 	}
@@ -206,6 +237,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	if fp, hit := e.cacheLookup(&g, expanded); hit {
 		e.outputs.Set(g.Name, fp.Output)
 		e.log.Info("cache hit", "group", g.Name, "fingerprint", fp.Fingerprint)
+		status = StatusCacheHit
 		return nil
 	}
 

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -1,0 +1,81 @@
+package engine
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+)
+
+// Event names emitted over the run lifecycle.
+const (
+	EventFlowStart  = "flow.start"
+	EventFlowEnd    = "flow.end"
+	EventGroupStart = "group.start"
+	EventGroupEnd   = "group.end"
+)
+
+// Group end statuses.
+const (
+	StatusOK       = "ok"
+	StatusFailed   = "failed"
+	StatusSkipped  = "skipped"
+	StatusCacheHit = "cache-hit"
+	StatusDryRun   = "dry-run"
+)
+
+// Event is a single structured run event for machine consumption (CI tooling).
+type Event struct {
+	Event      string    `json:"event"`
+	Flow       string    `json:"flow,omitempty"`
+	Group      string    `json:"group,omitempty"`
+	Mode       string    `json:"mode,omitempty"`
+	Status     string    `json:"status,omitempty"`
+	DurationMS int64     `json:"durationMs,omitempty"`
+	Err        string    `json:"err,omitempty"`
+	Time       time.Time `json:"time"`
+}
+
+// Emitter receives lifecycle events. Implementations must be safe for
+// concurrent use (groups run in parallel).
+type Emitter interface {
+	Emit(Event)
+}
+
+// nopEmitter discards events; the engine default.
+type nopEmitter struct{}
+
+func (nopEmitter) Emit(Event) {}
+
+// JSONEmitter writes one JSON object per line to a writer.
+type JSONEmitter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewJSONEmitter returns an Emitter that writes newline-delimited JSON to w.
+func NewJSONEmitter(w io.Writer) *JSONEmitter { return &JSONEmitter{w: w} }
+
+// Emit serializes ev as a single JSON line. Encoding errors are dropped — the
+// event stream is best-effort observability, never load-bearing.
+func (e *JSONEmitter) Emit(ev Event) { //nolint:gocritic // value receiver keeps the Emitter interface simple
+	if ev.Time.IsZero() {
+		ev.Time = time.Now()
+	}
+	b, err := json.Marshal(&ev)
+	if err != nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, _ = e.w.Write(append(b, '\n'))
+}
+
+func msSince(start time.Time) int64 { return time.Since(start).Milliseconds() }
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+func decodeEvents(t *testing.T, b []byte) []Event {
+	t.Helper()
+	var evs []Event
+	for line := range strings.SplitSeq(strings.TrimSpace(string(b)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e Event
+		require.NoError(t, json.Unmarshal([]byte(line), &e))
+		evs = append(evs, e)
+	}
+	return evs
+}
+
+// statusOf returns the end status emitted for a group.
+func statusOf(evs []Event, group string) string {
+	for i := range evs {
+		if evs[i].Event == EventGroupEnd && evs[i].Group == group {
+			return evs[i].Status
+		}
+	}
+	return ""
+}
+
+func TestJSONEmitter_FlowAndGroupEvents(t *testing.T) {
+	t.Parallel()
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo"}}, [][]string{{"a"}})
+	var buf bytes.Buffer
+	e := New(cfg, WithRunner(&fakeRunner{outputs: map[string]string{"a": "x"}}), WithEmitter(NewJSONEmitter(&buf)))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+
+	evs := decodeEvents(t, buf.Bytes())
+	// Expect flow.start, group.start, group.end, flow.end in order.
+	require.Len(t, evs, 4)
+	assert.Equal(t, EventFlowStart, evs[0].Event)
+	assert.Equal(t, "f", evs[0].Flow)
+	assert.Equal(t, EventGroupStart, evs[1].Event)
+	assert.Equal(t, EventGroupEnd, evs[2].Event)
+	assert.Equal(t, StatusOK, evs[2].Status)
+	assert.Equal(t, EventFlowEnd, evs[3].Event)
+	assert.Equal(t, StatusOK, evs[3].Status)
+}
+
+func TestJSONEmitter_Statuses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("failed", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "false"}}, [][]string{{"a"}})
+		var buf bytes.Buffer
+		e := New(cfg, WithRunner(&fakeRunner{errs: map[string]error{"a": errors.New("boom")}}), WithEmitter(NewJSONEmitter(&buf)))
+		_ = e.RunFlow(context.Background(), "f")
+		evs := decodeEvents(t, buf.Bytes())
+		assert.Equal(t, StatusFailed, statusOf(evs, "a"))
+		// flow.end is failed too.
+		assert.Equal(t, StatusFailed, evs[len(evs)-1].Status)
+	})
+
+	t.Run("skipped via skip-if", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo", SkipIf: "done"}}, [][]string{{"a"}})
+		var buf bytes.Buffer
+		p := &scriptedProber{results: map[string]error{"done": nil}}
+		e := New(cfg, WithRunner(&fakeRunner{}), WithProber(p), WithEmitter(NewJSONEmitter(&buf)))
+		require.NoError(t, e.RunFlow(context.Background(), "f"))
+		assert.Equal(t, StatusSkipped, statusOf(decodeEvents(t, buf.Bytes()), "a"))
+	})
+
+	t.Run("dry-run", func(t *testing.T) {
+		cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo"}}, [][]string{{"a"}})
+		var buf bytes.Buffer
+		e := New(cfg, WithRunner(&fakeRunner{}), WithDryRun(true), WithEmitter(NewJSONEmitter(&buf)))
+		require.NoError(t, e.RunFlow(context.Background(), "f"))
+		assert.Equal(t, StatusDryRun, statusOf(decodeEvents(t, buf.Bytes()), "a"))
+	})
+}
+
+func TestNopEmitterIsDefault(t *testing.T) {
+	t.Parallel()
+	// No emitter configured → no panic, runs fine.
+	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo"}}, [][]string{{"a"}})
+	e := New(cfg, WithRunner(&fakeRunner{}))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+}


### PR DESCRIPTION
## Summary

Adds a machine-readable run event stream for CI tooling, behind an `Emitter` abstraction (default: discard).

```sh
keepup run ci --events run.jsonl   # newline-delimited JSON to a file
keepup run ci --events -            # to stdout
```

Events: `flow.start`, `group.start`, `group.end` (with `status` ∈ ok/failed/skipped/cache-hit/dry-run and `durationMs`), `flow.end`. Independent of the human/JSON logging (`settings.logging`) — logs are for people, events are for tooling.

## Implementation

- `internal/engine/events.go`: `Event`, `Emitter` interface, `nopEmitter` (default), concurrency-safe `JSONEmitter` (mutex-guarded, newline-delimited).
- Engine emits flow.start/end in `RunFlow` and group.start/end in `runGroup` (status set per branch: dry-run/skipped/cache-hit/ok/failed via a deferred emit on the named return).
- `WithEmitter` option; CLI `run --events <path>` (`-` = stdout) wires `NewJSONEmitter`.

## Tests

- `engine`: full event sequence (flow.start→group.start→group.end→flow.end), and statuses for failed/skipped/dry-run; nop-emitter default doesn't panic.
- `cmd`: `--events -` (stdout) and `--events <file>` both produce the expected JSON.
- Smoke-tested end-to-end.

`go test -race ./...` clean; `golangci-lint run ./...` 0 issues.

## Docs

README feature row, CONFIG.md run-flag table, FAQ entry ("machine-readable run output for CI?").