### PR TITLE
feat: per-group when: in dag mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ shell unless you ask for it), and incremental re-runs via content-based caching.
 | **Caching**              | Per-group `cache: { reads, writes }` fingerprints inputs (hash or mtime) and skips unchanged work, replaying stored output. |
 | **Watch mode**           | `keepup watch` re-runs a flow on file changes (using each group's `cache.reads`); caching makes unaffected groups no-ops.   |
 | **Gating**               | `require:` (must pass) and `skip-if:` (skip when already done) predicates short-circuit a group before it runs.             |
+| **Conditionals**         | `when:` skips a step (step mode) or a single dag-mode group (dag mode); skipping a dag group cascades to all its dependents. |
 | **Timeouts & retries**   | Per-step / per-flow `timeout` and `retries` envelope around each command attempt, with backoff.                             |
 | **Safe execution**       | Commands run as real argv by default (no shell injection); opt into a shell per group with `shell:`.                        |
 | **Env layering**         | Global `env:` plus per-group overrides, merged over the process environment.                                                |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -308,7 +308,6 @@ and sprig) and is **falsey** — and therefore skips the step — when it render
 to `""`, `false`, `0`, `no`, or `off`. It is evaluated against the outputs of
 **earlier** steps plus the environment; referencing a same-step or later group
 is rejected at config-load. A skipped step's groups produce no output.
-`when:` applies to step mode only (dag mode has no steps).
 
 ### DAG mode
 
@@ -327,6 +326,45 @@ flows:
 
 For DAG mode the engine validates that the data graph is **acyclic** before
 running anything.
+
+#### Per-group `when:` in dag mode
+
+In dag mode each `run:` entry is either a bare group name (string) or a map
+with `group:` and `when:` keys:
+
+```yaml
+flows:
+  ci:
+    mode: dag
+    run:
+      - build
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'
+      - report
+```
+
+The map form accepts **only** `group` and `when` — no `command`, `params`, or
+other group-definition keys. Those fields belong on the group definition in
+`groups:`. An unexpected key is a config error at load time.
+
+`group:` is the name of a group already declared in the top-level `groups:`
+list (no inline definitions). `when:` follows the same template engine and
+falsey set as step-mode `when:` (`""`, `"false"`, `"0"`, `"no"`, `"off"`).
+
+**`when:` references create scheduling edges.** If `when: '{{ eq (output "x")
+"pass" }}'` references group `x`, then `x` becomes a predecessor in the data
+graph — it is guaranteed to finish before the predicate is evaluated, and the
+reference participates in the acyclic-graph check (cycle detection applies).
+
+**Cascade skip.** When a group is skipped by its `when:`, every group
+downstream of it — anything that depends on its output, transitively — is also
+skipped. A group cannot run on a missing producer's output. Cascade-skipped
+groups report `"reason":"upstream \"<name>\" skipped"` in their `group.end`
+event. A skip is not a failure: the flow can still end with `"status":"ok"`.
+
+Existing bare-string `run:` entries are unchanged — the map form is purely
+additive.
 
 When should you use each?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -291,6 +291,15 @@ $ keepup run release --config keepup.yml --events -
 A cascade skip is not a failure — the flow ends with `"status":"ok"` as long
 as no group actually errored.
 
+### Does `--dry-run` evaluate `when:` predicates?
+
+Yes. `when:` predicates have no side effects, so they evaluate normally in
+`--dry-run`, and the dry run reveals the real control flow — including which
+groups would be skipped and which dependents would cascade. A `when:`-skipped
+group emits `"status":"skipped"` (skip wins over dry-run because the decision
+happens before the group would be launched); other groups emit
+`"status":"dry-run"`.
+
 ### How does `when:` differ from a group's `skip-if`?
 
 `when:` is on a **step** (step mode) or a **dag run entry** (dag mode) and

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -239,14 +239,67 @@ the cache is written only on success, so a failed/timed-out run can't poison
 it. In dag mode there are no steps, so the flow-level values are the only
 envelope.
 
+### Can I make a single group in a dag flow conditional?
+
+Yes. Instead of a bare group name, write a map with `group:` and `when:` keys:
+
+```yaml
+flows:
+  ci:
+    mode: dag
+    run:
+      - build
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'
+      - report
+```
+
+`when:` uses the same template engine and falsey set as step-mode `when:`
+(`""`, `"false"`, `"0"`, `"no"`, `"off"`). The map form accepts **only**
+`group` and `when` — `command`, `params`, and other group fields belong on the
+group definition in `groups:`. An unexpected key is a config error.
+
+References inside `when:` (e.g. `output "test"`) become scheduling edges:
+`test` is guaranteed to finish before the predicate runs, and the reference
+participates in the cycle check.
+
+Bare-string entries in `run:` are unchanged — the map form is purely additive.
+
+### What happens to groups that depend on a skipped dag group?
+
+They are **cascade-skipped**: a group that depends (directly or transitively)
+on a skipped group's output cannot run, because the producer's output is
+absent. Each cascade-skipped group emits a `group.end` event with
+`"status":"skipped"` and a `"reason"` explaining which upstream group was
+skipped.
+
+Example: a `release` flow where `deploy` is gated on `DEPLOY=true` and
+`notify` depends on `deploy`:
+
+```sh
+$ keepup run release --config keepup.yml --events -
+{"event":"flow.start","flow":"release","mode":"dag"}
+{"event":"group.end","group":"deploy","status":"skipped","reason":"when"}
+{"event":"group.end","group":"notify","status":"skipped","reason":"upstream \"deploy\" skipped"}
+{"event":"group.end","group":"build","status":"ok","durationMs":2}
+{"event":"flow.end","flow":"release","status":"ok","durationMs":2}
+```
+
+`"reason":"when"` marks the directly-gated group; `"reason":"upstream
+\"deploy\" skipped"` marks groups skipped because their producer was skipped.
+A cascade skip is not a failure — the flow ends with `"status":"ok"` as long
+as no group actually errored.
+
 ### How does `when:` differ from a group's `skip-if`?
 
-`when:` is on a **step** and decides whether the whole wave runs; `skip-if:` is
-on a **group** and decides whether that one group runs. `when:` is a template
-predicate (uses `output`/`env`/sprig, falsey = skip) evaluated against earlier
-steps' outputs; `skip-if:` is a shell command (exit 0 = skip) run just before
+`when:` is on a **step** (step mode) or a **dag run entry** (dag mode) and
+decides whether that wave or individual group runs; `skip-if:` is on a
+**group** and decides whether that one group runs. `when:` is a template
+predicate (uses `output`/`env`/sprig, falsey = skip) evaluated against
+prior outputs; `skip-if:` is a shell command (exit 0 = skip) run just before
 the group. Use `when:` for "should this phase happen at all?" and `skip-if:`
-for "is this group's work already done?". `when:` is step-mode only.
+for "is this group's work already done?".
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -155,6 +155,67 @@ shell-interpreted single line:
 Use shell mode only when you actually need shell features (`|`, `$()`,
 globs, …).
 
+## Conditional dag groups
+
+In dag mode a single `run:` entry can carry a `when:` predicate so it only
+runs when a condition is met. The group is skipped (not failed) when the
+predicate is falsey; any group that depends on its output is cascade-skipped.
+
+```yaml
+groups:
+  - name: build
+    command: go
+    params: [build, -o, bin/app, ./]
+  - name: test
+    command: go
+    params: [test, ./...]
+  - name: deploy
+    command: ./scripts/deploy.sh
+    params: ['{{ output "test" }}']
+  - name: report
+    command: ./scripts/notify.sh
+
+flows:
+  ci:
+    mode: dag
+    run:
+      - build
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'
+      - report
+```
+
+Run it and watch the event stream:
+
+```sh
+keepup run ci --config keepup.yml --events -
+```
+
+When tests pass, all groups run:
+
+```
+{"event":"flow.start","flow":"ci","mode":"dag"}
+{"event":"group.end","group":"build","status":"ok","durationMs":3}
+{"event":"group.end","group":"test","status":"ok","durationMs":4}
+{"event":"group.end","group":"deploy","status":"ok","durationMs":3}
+{"event":"group.end","group":"report","status":"ok","durationMs":3}
+{"event":"flow.end","flow":"ci","status":"ok","durationMs":11}
+```
+
+When the predicate is falsey (e.g. `DEPLOY` unset in an env-gated flow),
+`deploy` is skipped and any downstream group is cascade-skipped:
+
+```
+{"event":"flow.start","flow":"release","mode":"dag"}
+{"event":"group.end","group":"deploy","status":"skipped","reason":"when"}
+{"event":"group.end","group":"notify","status":"skipped","reason":"upstream \"deploy\" skipped"}
+{"event":"group.end","group":"build","status":"ok","durationMs":2}
+{"event":"flow.end","flow":"release","status":"ok","durationMs":2}
+```
+
+The flow still ends `"status":"ok"` — a skip is not an error.
+
 ## More
 
 - [Configuration](CONFIG.md) — every field, defaults, semantics

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,12 +115,12 @@ func (g *Group) UseShell() bool { return g.Shell != "" }
 // in the flow. In step mode a Step may override them for its own wave; in dag
 // mode the flow-level values are the only knob (there are no steps).
 type Flow struct {
-	Description string   `yaml:"description,omitempty"`
-	Mode        Mode     `yaml:"mode,omitempty"`
-	Steps       []Step   `yaml:"steps,omitempty"`
-	Run         []string `yaml:"run,omitempty"`
-	Timeout     string   `yaml:"timeout,omitempty"`
-	Retries     int      `yaml:"retries,omitempty"`
+	Description string     `yaml:"description,omitempty"`
+	Mode        Mode       `yaml:"mode,omitempty"`
+	Steps       []Step     `yaml:"steps,omitempty"`
+	Run         []RunEntry `yaml:"run,omitempty"`
+	Timeout     string     `yaml:"timeout,omitempty"`
+	Retries     int        `yaml:"retries,omitempty"`
 }
 
 // Step is one execution wave inside a step-mode Flow.
@@ -135,6 +135,46 @@ type Step struct {
 	// renders to a falsey value ("", "false", "0", "no", "off"). It is
 	// evaluated against the outputs of earlier steps plus the environment.
 	When string `yaml:"when,omitempty"`
+}
+
+// RunEntry is one member of a dag-mode flow's run list. It is either a bare
+// group-name scalar or a {group, when} mapping; both forms reference a group
+// defined in top-level groups: (never an inline definition).
+type RunEntry struct {
+	Group string `yaml:"group"`
+	// When is an optional template predicate. The group is skipped when it
+	// renders falsey ("", "false", "0", "no", "off"); see the engine.
+	When string `yaml:"when,omitempty"`
+}
+
+// UnmarshalYAML accepts a scalar (group name) or a mapping ({group, when}).
+// Any other shape, an empty group, or an unexpected key is a load error.
+func (r *RunEntry) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		r.Group = node.Value
+		return nil
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			val := node.Content[i+1].Value
+			switch key {
+			case "group":
+				r.Group = val
+			case "when":
+				r.When = val
+			default:
+				return fmt.Errorf("run entry: unexpected key %q (commands are defined in groups:)", key)
+			}
+		}
+		if r.Group == "" {
+			return fmt.Errorf("run entry: missing 'group'")
+		}
+		return nil
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
+		return fmt.Errorf("run entry: must be a group name or a {group, when} map")
+	}
+	return fmt.Errorf("run entry: must be a group name or a {group, when} map")
 }
 
 // NewConfig parses YAML bytes into a Config and validates the schema.
@@ -326,7 +366,11 @@ func (c *Config) GroupByName(name string) *Group {
 // Members returns the groups referenced by a flow, regardless of mode.
 func (f *Flow) Members() []string {
 	if f.Mode == ModeDAG {
-		return append([]string(nil), f.Run...)
+		out := make([]string, len(f.Run))
+		for i := range f.Run {
+			out[i] = f.Run[i].Group
+		}
+		return out
 	}
 	out := make([]string, 0)
 	for _, s := range f.Steps {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,9 @@ type RunEntry struct {
 func (r *RunEntry) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
+		if node.Value == "" {
+			return fmt.Errorf("run entry: group name must not be empty")
+		}
 		r.Group = node.Value
 		return nil
 	case yaml.MappingNode:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,12 +160,18 @@ func (r *RunEntry) UnmarshalYAML(node *yaml.Node) error {
 	case yaml.MappingNode:
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := node.Content[i].Value
-			val := node.Content[i+1].Value
+			valNode := node.Content[i+1]
 			switch key {
 			case "group":
-				r.Group = val
+				if valNode.Kind != yaml.ScalarNode {
+					return fmt.Errorf(`run entry: "group" must be a string`)
+				}
+				r.Group = valNode.Value
 			case "when":
-				r.When = val
+				if valNode.Kind != yaml.ScalarNode {
+					return fmt.Errorf(`run entry: "when" must be a string`)
+				}
+				r.When = valNode.Value
 			default:
 				return fmt.Errorf("run entry: unexpected key %q (commands are defined in groups:)", key)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -738,6 +738,71 @@ flows:
 	}
 }
 
+func TestDAGWhenRefValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name: "when ref to flow member is ok",
+			doc: `version: 2
+groups:
+  - {name: test, command: echo}
+  - {name: deploy, command: echo}
+flows:
+  ci:
+    mode: dag
+    run:
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'`,
+		},
+		{
+			name: "when ref to non-member is rejected",
+			doc: `version: 2
+groups:
+  - {name: deploy, command: echo}
+  - {name: lint, command: echo}
+flows:
+  ci:
+    mode: dag
+    run:
+      - group: deploy
+        when: '{{ output "lint" }}'`,
+			wantErr: "is not part of this flow",
+		},
+		{
+			name: "when ref forming a cycle is rejected",
+			doc: `version: 2
+groups:
+  - {name: a, command: 'echo {{ output "b" }}'}
+  - {name: b, command: echo}
+flows:
+  ci:
+    mode: dag
+    run:
+      - a
+      - group: b
+        when: '{{ output "a" }}'`,
+			wantErr: "cycle",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewConfig([]byte(tc.doc))
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 func TestFlowMembersDAGFromRunEntries(t *testing.T) {
 	t.Parallel()
 	f := Flow{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -803,6 +803,21 @@ flows:
 	}
 }
 
+func TestLoadDAGWhenFixture(t *testing.T) {
+	t.Parallel()
+	cfg, err := LoadConfig("./test-resources/config-dag-when.yml")
+	require.NoError(t, err)
+
+	f := cfg.Flows["ci"]
+	assert.Equal(t, ModeDAG, f.Mode)
+	assert.Equal(t, []RunEntry{
+		{Group: "build"},
+		{Group: "test"},
+		{Group: "deploy", When: `{{ eq (output "test") "pass" }}`},
+		{Group: "report"},
+	}, f.Run)
+}
+
 func TestFlowMembersDAGFromRunEntries(t *testing.T) {
 	t.Parallel()
 	f := Flow{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -645,7 +645,7 @@ func TestMembers(t *testing.T) {
 		assert.Equal(t, []string{"a", "b", "c"}, f.Members())
 	})
 	t.Run("dag mode returns run set", func(t *testing.T) {
-		f := Flow{Mode: ModeDAG, Run: []string{"a", "b"}}
+		f := Flow{Mode: ModeDAG, Run: []RunEntry{{Group: "a"}, {Group: "b"}}}
 		assert.Equal(t, []string{"a", "b"}, f.Members())
 	})
 }
@@ -655,4 +655,83 @@ func TestGroupByName(t *testing.T) {
 	cfg := &Config{Groups: []Group{{Name: "a"}, {Name: "b"}}}
 	assert.NotNil(t, cfg.GroupByName("a"))
 	assert.Nil(t, cfg.GroupByName("missing"))
+}
+
+func TestRunEntryUnmarshal(t *testing.T) {
+	t.Parallel()
+	valid := `version: 2
+groups:
+  - {name: build, command: echo}
+  - {name: deploy, command: echo}
+flows:
+  f:
+    mode: dag
+    run:
+      - build
+      - group: deploy
+        when: 'x'`
+	cfg, err := NewConfig([]byte(valid))
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]RunEntry{{Group: "build"}, {Group: "deploy", When: "x"}},
+		cfg.Flows["f"].Run,
+	)
+
+	errCases := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name: "unexpected key",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - group: deploy
+        command: ./x.sh`,
+			wantErr: `unexpected key "command"`,
+		},
+		{
+			name: "missing group",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - when: 'x'`,
+			wantErr: "missing 'group'",
+		},
+		{
+			name: "wrong node kind",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - [nested]`,
+			wantErr: "must be a group name or a {group, when} map",
+		},
+	}
+	for _, tc := range errCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewConfig([]byte(tc.doc))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestFlowMembersDAGFromRunEntries(t *testing.T) {
+	t.Parallel()
+	f := Flow{
+		Mode: ModeDAG,
+		Run:  []RunEntry{{Group: "build"}, {Group: "deploy", When: "x"}},
+	}
+	assert.Equal(t, []string{"build", "deploy"}, f.Members())
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -716,6 +716,17 @@ flows:
       - [nested]`,
 			wantErr: "must be a group name or a {group, when} map",
 		},
+		{
+			name: "empty scalar group",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - ""`,
+			wantErr: "group name must not be empty",
+		},
 	}
 	for _, tc := range errCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -657,9 +657,9 @@ func TestGroupByName(t *testing.T) {
 	assert.Nil(t, cfg.GroupByName("missing"))
 }
 
-func TestRunEntryUnmarshal(t *testing.T) {
+func TestRunEntryUnmarshal_Valid(t *testing.T) {
 	t.Parallel()
-	valid := `version: 2
+	doc := `version: 2
 groups:
   - {name: build, command: echo}
   - {name: deploy, command: echo}
@@ -670,13 +670,16 @@ flows:
       - build
       - group: deploy
         when: 'x'`
-	cfg, err := NewConfig([]byte(valid))
+	cfg, err := NewConfig([]byte(doc))
 	require.NoError(t, err)
 	assert.Equal(t,
 		[]RunEntry{{Group: "build"}, {Group: "deploy", When: "x"}},
 		cfg.Flows["f"].Run,
 	)
+}
 
+func TestRunEntryUnmarshal_Errors(t *testing.T) {
+	t.Parallel()
 	errCases := []struct {
 		name    string
 		doc     string
@@ -727,6 +730,32 @@ flows:
       - ""`,
 			wantErr: "group name must not be empty",
 		},
+		{
+			// Bug #1 from self-review: silently accepted non-scalar values.
+			name: "when value is a mapping not a string",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - group: deploy
+        when:
+          nested: 'true'`,
+			wantErr: `"when" must be a string`,
+		},
+		{
+			// Bug #1: non-scalar 'group' value.
+			name: "group value is a sequence not a string",
+			doc: `version: 2
+groups: [{name: deploy, command: echo}]
+flows:
+  f:
+    mode: dag
+    run:
+      - group: [a, b]`,
+			wantErr: `"group" must be a string`,
+		},
 	}
 	for _, tc := range errCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -771,7 +800,9 @@ flows:
     run:
       - group: deploy
         when: '{{ output "lint" }}'`,
-			wantErr: "is not part of this flow",
+			// #12 from self-review: error must distinguish a when: source from a
+			// command-ref source, mirroring step mode ("when references ...").
+			wantErr: "when references",
 		},
 		{
 			name: "when ref forming a cycle is rejected",
@@ -801,6 +832,28 @@ flows:
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+// TestDAGDuplicateGroupRejected covers bug #2 from the self-review: a dag
+// flow with the same group listed twice silently accepted last-wins for the
+// when: predicate. The second entry now produces a clear validation error.
+func TestDAGDuplicateGroupRejected(t *testing.T) {
+	t.Parallel()
+	doc := `version: 2
+groups:
+  - {name: deploy, command: echo}
+flows:
+  ci:
+    mode: dag
+    run:
+      - group: deploy
+        when: '{{ env "A" }}'
+      - group: deploy
+        when: '{{ env "B" }}'`
+	_, err := NewConfig([]byte(doc))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `group "deploy"`)
+	assert.Contains(t, err.Error(), "duplicate")
 }
 
 func TestLoadDAGWhenFixture(t *testing.T) {

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -132,8 +132,17 @@ func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, member
 	for _, m := range members {
 		inDeg[m] = 0
 	}
-	addEdge := func(ref, m string) error {
+	// addEdge records ref -> m in the data graph. fromWhen toggles the error
+	// phrasing so a `when:` reference reads "when references {{ output.X }}"
+	// (mirroring step mode), distinguishing it from a command/param reference.
+	addEdge := func(ref, m string, fromWhen bool) error {
 		if _, ok := memberSet[ref]; !ok {
+			if fromWhen {
+				return fmt.Errorf(
+					"flow %q: group %q: when references {{ output.%s }}, but %q is not part of this flow",
+					flowName, m, ref, ref,
+				)
+			}
 			return fmt.Errorf(
 				"flow %q: group %q references {{ output.%s }}, but %q is not part of this flow",
 				flowName, m, ref, ref,
@@ -146,8 +155,20 @@ func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, member
 		inDeg[m]++
 		return nil
 	}
+	// seen catches the same group listed twice in run: — both bare strings and
+	// {group, when} maps. With per-entry `when:` predicates, last-wins would
+	// silently swallow a predicate; reject it at load.
+	seen := make(map[string]struct{}, len(f.Run))
 	for i := range f.Run {
 		m := f.Run[i].Group
+		if _, dup := seen[m]; dup {
+			return fmt.Errorf(
+				"flow %q: group %q is listed more than once in run: (duplicate dag entries are not allowed)",
+				flowName, m,
+			)
+		}
+		seen[m] = struct{}{}
+
 		g := c.GroupByName(m)
 		if g == nil {
 			return fmt.Errorf("flow %q: group %q is not defined", flowName, m)
@@ -157,7 +178,7 @@ func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, member
 			return fmt.Errorf("flow %q: %w", flowName, err)
 		}
 		for _, ref := range refs {
-			if err := addEdge(ref, m); err != nil {
+			if err := addEdge(ref, m, false); err != nil {
 				return err
 			}
 		}
@@ -168,7 +189,7 @@ func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, member
 				return fmt.Errorf("flow %q: group %q: when: %w", flowName, m, werr)
 			}
 			for _, ref := range whenRefs {
-				if err := addEdge(ref, m); err != nil {
+				if err := addEdge(ref, m, true); err != nil {
 					return err
 				}
 			}

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -59,7 +59,7 @@ func (c *Config) checkFlowRefs(flowName string, f *Flow, members []string) error
 	case ModeStep:
 		return c.checkStepRefs(flowName, f, memberSet)
 	case ModeDAG:
-		return c.checkDAGRefs(flowName, members, memberSet)
+		return c.checkDAGRefs(flowName, f, members, memberSet)
 	}
 	return nil
 }
@@ -124,13 +124,28 @@ func (c *Config) checkWhenRefs(flowName string, stepIdx int, when string, member
 	return nil
 }
 
-func (c *Config) checkDAGRefs(flowName string, members []string, memberSet map[string]struct{}) error {
+func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, memberSet map[string]struct{}) error {
 	adj := make(map[string][]string, len(members))
 	inDeg := make(map[string]int, len(members))
 	for _, m := range members {
 		inDeg[m] = 0
 	}
-	for _, m := range members {
+	addEdge := func(ref, m string) error {
+		if _, ok := memberSet[ref]; !ok {
+			return fmt.Errorf(
+				"flow %q: group %q references {{ output.%s }}, but %q is not part of this flow",
+				flowName, m, ref, ref,
+			)
+		}
+		if ref == m {
+			return fmt.Errorf("flow %q: group %q references its own output", flowName, m)
+		}
+		adj[ref] = append(adj[ref], m)
+		inDeg[m]++
+		return nil
+	}
+	for i := range f.Run {
+		m := f.Run[i].Group
 		g := c.GroupByName(m)
 		if g == nil {
 			return fmt.Errorf("flow %q: group %q is not defined", flowName, m)
@@ -140,17 +155,21 @@ func (c *Config) checkDAGRefs(flowName string, members []string, memberSet map[s
 			return fmt.Errorf("flow %q: %w", flowName, err)
 		}
 		for _, ref := range refs {
-			if _, ok := memberSet[ref]; !ok {
-				return fmt.Errorf(
-					"flow %q: group %q references {{ output.%s }}, but %q is not part of this flow",
-					flowName, m, ref, ref,
-				)
+			if err := addEdge(ref, m); err != nil {
+				return err
 			}
-			if ref == m {
-				return fmt.Errorf("flow %q: group %q references its own output", flowName, m)
+		}
+		// when: references create edges exactly like command/param refs.
+		if w := f.Run[i].When; w != "" {
+			whenRefs, werr := template.Refs(w)
+			if werr != nil {
+				return fmt.Errorf("flow %q: group %q: when: %w", flowName, m, werr)
 			}
-			adj[ref] = append(adj[ref], m)
-			inDeg[m]++
+			for _, ref := range whenRefs {
+				if err := addEdge(ref, m); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return topoCheck(flowName, members, adj, inDeg)

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -35,7 +35,9 @@ func ExtractRefs(g *Group) ([]string, error) {
 //
 //   - every {{ output.X }} must point to a group that appears earlier in the
 //     same flow (step mode: in an earlier step; dag mode: in the flow's run
-//     set, with the resulting data DAG being acyclic).
+//     set, with the resulting data DAG being acyclic — including references
+//     inside `when:` predicates, which are treated as graph edges and
+//     cycle-checked).
 //   - dag mode additionally rejects cycles.
 //
 // It is invoked from normalizeAndValidate so a single LoadConfig surfaces

--- a/internal/config/test-resources/config-dag-when.yml
+++ b/internal/config/test-resources/config-dag-when.yml
@@ -1,0 +1,25 @@
+---
+# Exercises dag-mode per-group `when:` and skip cascade:
+#   - deploy is gated on test's output (when: ref creates a test -> deploy edge)
+#   - report consumes deploy's output (deploy -> report edge); if deploy is
+#     skipped, report cascade-skips because its producer never ran.
+version: 2
+
+default: ci
+
+groups:
+  - { name: build, command: echo, params: ["built"] }
+  - { name: test, command: echo, params: ["pass"] }
+  - { name: deploy, command: echo, params: ["deploying"] }
+  - { name: report, command: echo, params: ['{{ output "deploy" }}'] }
+
+flows:
+  ci:
+    description: "Conditional deploy gated on test; report consumes deploy output"
+    mode: dag
+    run:
+      - build
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'
+      - report

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -56,11 +56,15 @@ func stepFlowCfg(t *testing.T, groups []config.Group, steps [][]string) *config.
 }
 
 func dagFlowCfg(_ *testing.T, groups []config.Group, run []string) *config.Config {
+	entries := make([]config.RunEntry, len(run))
+	for i, name := range run {
+		entries[i] = config.RunEntry{Group: name}
+	}
 	return &config.Config{
 		Version: config.SchemaVersion,
 		Groups:  groups,
 		Flows: map[string]config.Flow{
-			"f": {Mode: config.ModeDAG, Run: append([]string(nil), run...)},
+			"f": {Mode: config.ModeDAG, Run: entries},
 		},
 	}
 }

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -33,6 +33,7 @@ type Event struct {
 	Status     string    `json:"status,omitempty"`
 	DurationMS int64     `json:"durationMs,omitempty"`
 	Err        string    `json:"err,omitempty"`
+	Reason     string    `json:"reason,omitempty"`
 	Time       time.Time `json:"time"`
 }
 

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -124,4 +124,16 @@ func TestJSONEmitter_DAGSkippedReason(t *testing.T) {
 	assert.Equal(t, StatusSkipped, statusOf(evs, "report"))
 	assert.Equal(t, "when", reasonOf(evs, "deploy"))
 	assert.Contains(t, reasonOf(evs, "report"), "deploy")
+
+	// Gap #8 from self-review: a skip cascade is NOT a failure — the flow
+	// itself must still end "ok" so CI tooling doesn't mistake a conditional
+	// branch for a broken run.
+	var flowEnd Event
+	for i := range evs {
+		if evs[i].Event == EventFlowEnd {
+			flowEnd = evs[i]
+		}
+	}
+	assert.Equal(t, EventFlowEnd, flowEnd.Event, "flow.end event must be emitted")
+	assert.Equal(t, StatusOK, flowEnd.Status, "skip cascade must not turn flow.end into a failure")
 }

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -38,6 +38,16 @@ func statusOf(evs []Event, group string) string {
 	return ""
 }
 
+// reasonOf returns the end reason emitted for a group.
+func reasonOf(evs []Event, group string) string {
+	for i := range evs {
+		if evs[i].Event == EventGroupEnd && evs[i].Group == group {
+			return evs[i].Reason
+		}
+	}
+	return ""
+}
+
 func TestJSONEmitter_FlowAndGroupEvents(t *testing.T) {
 	t.Parallel()
 	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo"}}, [][]string{{"a"}})
@@ -95,4 +105,23 @@ func TestNopEmitterIsDefault(t *testing.T) {
 	cfg := stepFlowCfg(t, []config.Group{{Name: "a", Command: "echo"}}, [][]string{{"a"}})
 	e := New(cfg, WithRunner(&fakeRunner{}))
 	require.NoError(t, e.RunFlow(context.Background(), "f"))
+}
+
+func TestJSONEmitter_DAGSkippedReason(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-dag-when.yml")
+	require.NoError(t, err)
+
+	// test outputs "fail" -> deploy.when false -> deploy skipped (reason "when")
+	// -> report cascade-skipped (reason mentions upstream deploy).
+	var buf bytes.Buffer
+	r := &fakeRunner{outputs: map[string]string{"build": "built", "test": "fail"}}
+	e := New(cfg, WithRunner(r), WithEmitter(NewJSONEmitter(&buf)))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	evs := decodeEvents(t, buf.Bytes())
+	assert.Equal(t, StatusSkipped, statusOf(evs, "deploy"))
+	assert.Equal(t, StatusSkipped, statusOf(evs, "report"))
+	assert.Equal(t, "when", reasonOf(evs, "deploy"))
+	assert.Contains(t, reasonOf(evs, "report"), "deploy")
 }

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"sync"
 
@@ -11,43 +12,126 @@ import (
 	"github.com/quike/keepup/internal/plan"
 )
 
+// dagSched holds the scheduler-goroutine-local bookkeeping for a dag run. Every
+// field and method here is touched only by the single scheduler goroutine, so
+// none of it needs synchronization; workers communicate solely through doneCh
+// and the snapMu-guarded snapshot owned by runDAGPlan.
+type dagSched struct {
+	e      *Engine
+	p      *plan.Plan
+	indeg  map[string]int
+	skip   map[string]bool
+	reason map[string]string
+	ready  []string
+
+	pending int
+	err     error
+
+	launch func(name string)
+	cancel context.CancelFunc
+
+	baseline func() map[string]string // stable snapshot for when: evaluation
+}
+
+// onDone resolves a terminal node's successors. A skipped node poisons its
+// successors (first poisoner wins the reason); every successor's indeg is
+// decremented and those that reach zero join the ready worklist.
+func (s *dagSched) onDone(name string, wasSkipped bool) {
+	s.pending--
+	for _, succ := range s.p.Successors[name] {
+		if wasSkipped && !s.skip[succ] {
+			s.skip[succ] = true
+			s.reason[succ] = fmt.Sprintf("upstream %q skipped", name)
+		}
+		s.indeg[succ]--
+		if s.indeg[succ] == 0 {
+			s.ready = append(s.ready, succ)
+		}
+	}
+}
+
+// decide reports whether name should be skipped, evaluating its when: predicate
+// against a stable snapshot when one is declared. A predicate error records
+// s.err, cancels the run, and reports skip=true to unwind the worklist quickly.
+func (s *dagSched) decide(name string) bool {
+	if s.skip[name] {
+		return true
+	}
+	expr := s.p.When[name]
+	if expr == "" {
+		return false
+	}
+	run, err := s.e.evalWhen(expr, s.baseline())
+	if err != nil {
+		s.err = fmt.Errorf("flow %q: group %q: when: %w", s.p.Flow, name, err)
+		s.cancel()
+		return true
+	}
+	if !run {
+		s.reason[name] = "when"
+		return true
+	}
+	return false
+}
+
+// drainReady decides each ready node: skip (cascading synchronously) or launch.
+// A skip can make successors ready, which may themselves skip, so this loops
+// until the worklist is empty or a predicate error aborts the run.
+func (s *dagSched) drainReady() {
+	for len(s.ready) > 0 {
+		name := s.ready[len(s.ready)-1]
+		s.ready = s.ready[:len(s.ready)-1]
+
+		if s.decide(name) {
+			if s.err != nil {
+				return
+			}
+			s.skip[name] = true
+			s.e.emitGroupSkipped(name, s.reason[name])
+			s.onDone(name, true)
+			continue
+		}
+		s.launch(name)
+	}
+}
+
 // runDAGPlan runs the topological closure of the plan. A group starts as soon
-// as every group it references via {{ output.X }} has finished. The classical
-// Kahn-style ready queue is layered on top of errgroup so cancellation and
-// max-concurrency carry over without bespoke synchronization. Every group runs
-// under the flow-level envelope (dag mode has no per-step overrides).
+// as every group it references (via {{ output.X }} in command/params OR in its
+// when: predicate) has finished. A group whose when: predicate renders falsey
+// is skipped, and every group downstream of it cascades to skipped too — a
+// consumer cannot run on a producer's missing output.
+//
+// All skip decisions and bookkeeping live in this single scheduler goroutine
+// (the dagSched value); workers only run groups, publish outputs under snapMu,
+// and signal completion on doneCh. That keeps the conditional logic free of
+// additional synchronization.
 func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow) error {
 	env := resolveEnvelope(flow, nil)
-	// indeg tracks unresolved predecessors per group. It is mutated by the
-	// scheduler goroutine only.
-	indeg := make(map[string]int, len(p.Members))
-	for _, m := range p.Members {
-		indeg[m] = len(p.Predecessors[m])
-	}
 
-	// doneCh carries finished group names from workers back to the scheduler.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	doneCh := make(chan string, len(p.Members))
-
 	g, gctx := errgroup.WithContext(ctx)
 	if e.maxConcurrency > 0 {
 		g.SetLimit(e.maxConcurrency)
 	}
 
-	// Outputs are appended to a flow-local snapshot as groups finish. This
-	// snapshot is what we hand to each newly-ready group so reads are stable.
 	var (
 		snapMu sync.RWMutex
 		snap   = make(map[string]string, len(p.Members))
 	)
 	maps.Copy(snap, e.outputs.Snapshot())
+	baseline := func() map[string]string {
+		snapMu.RLock()
+		defer snapMu.RUnlock()
+		return cloneSnapshot(snap)
+	}
 
 	launch := func(name string) {
 		group := e.groups[name]
 		g.Go(func() error {
-			snapMu.RLock()
-			baseline := cloneSnapshot(snap)
-			snapMu.RUnlock()
-			if err := e.runGroup(gctx, &group, baseline, env); err != nil {
+			if err := e.runGroup(gctx, &group, baseline(), env); err != nil {
 				return err
 			}
 			if v, ok := e.outputs.Get(name); ok {
@@ -63,29 +147,56 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow
 		})
 	}
 
-	pending := len(p.Members)
-	for _, r := range p.Roots {
-		launch(r)
+	s := &dagSched{
+		e:        e,
+		p:        p,
+		indeg:    make(map[string]int, len(p.Members)),
+		skip:     make(map[string]bool, len(p.Members)),
+		reason:   make(map[string]string, len(p.Members)),
+		ready:    append(make([]string, 0, len(p.Members)), p.Roots...),
+		pending:  len(p.Members),
+		launch:   launch,
+		cancel:   cancel,
+		baseline: baseline,
+	}
+	for _, m := range p.Members {
+		s.indeg[m] = len(p.Predecessors[m])
 	}
 
-	// Scheduler loop: dispatch successors as their predecessors complete.
-loop:
-	for pending > 0 {
+	s.drainReady()
+	if s.err == nil {
+		e.runDAGLoop(gctx, doneCh, s)
+	}
+
+	if err := g.Wait(); err != nil && s.err == nil {
+		return err
+	}
+	return s.err
+}
+
+// runDAGLoop pumps completed groups from doneCh back into the scheduler until
+// every group has terminated (run or skipped), a predicate error aborts, or the
+// context is canceled.
+func (e *Engine) runDAGLoop(gctx context.Context, doneCh <-chan string, s *dagSched) {
+	for s.pending > 0 {
 		select {
 		case finished := <-doneCh:
-			pending--
-			for _, succ := range p.Successors[finished] {
-				indeg[succ]--
-				if indeg[succ] == 0 {
-					launch(succ)
-				}
+			s.onDone(finished, false)
+			s.drainReady()
+			if s.err != nil {
+				return
 			}
 		case <-gctx.Done():
-			break loop
+			return
 		}
 	}
+}
 
-	return g.Wait()
+// emitGroupSkipped reports a skipped dag group: a log line carrying the reason
+// and a group.end event marking it skipped on the structured stream.
+func (e *Engine) emitGroupSkipped(name, reason string) {
+	e.log.Info("group skipped", "group", name, "reason", reason)
+	e.emitter.Emit(Event{Event: EventGroupEnd, Group: name, Status: StatusSkipped})
 }
 
 func cloneSnapshot(m map[string]string) map[string]string {

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -12,20 +12,35 @@ import (
 	"github.com/quike/keepup/internal/plan"
 )
 
-// dagSched holds the scheduler-goroutine-local bookkeeping for a dag run. Every
-// field and method here is touched only by the single scheduler goroutine, so
-// none of it needs synchronization; workers communicate solely through doneCh
-// and the snapMu-guarded snapshot owned by runDAGPlan.
-type dagSched struct {
-	e      *Engine
-	p      *plan.Plan
-	indeg  map[string]int
-	skip   map[string]bool
-	reason map[string]string
-	ready  []string
+// dagScheduler holds the scheduler-goroutine-local bookkeeping for a dag run.
+// Every field and method here is touched only by the single scheduler goroutine,
+// so none of it needs synchronization; workers communicate solely through
+// doneCh and the snapMu-guarded snapshot owned by runDAGPlan.
+type dagScheduler struct {
+	engine *Engine
+	plan   *plan.Plan
 
-	pending int
-	err     error
+	// unresolvedPreds counts each group's predecessors that have not yet
+	// reached a terminal state (run or skipped). A group becomes ready when
+	// its count drops to zero.
+	unresolvedPreds map[string]int
+	// skipped marks groups the scheduler has decided to skip — either because
+	// their own when: rendered falsey, or because they are downstream of a
+	// skipped group (cascade).
+	skipped map[string]bool
+	// skipReason carries the human-readable reason for each skip ("when" or
+	// `upstream "<name>" skipped`), surfaced to logs and the event stream.
+	skipReason map[string]string
+	// ready is the worklist of groups whose predecessors are all terminal and
+	// that still need a skip-or-launch decision.
+	ready []string
+
+	// remaining is the count of groups not yet at a terminal state; the run
+	// is complete when it reaches zero.
+	remaining int
+	// schedErr records a scheduler-originated failure (e.g. a when: render
+	// error). It is propagated ahead of any worker error from g.Wait().
+	schedErr error
 
 	launch func(name string)
 	cancel context.CancelFunc
@@ -34,17 +49,18 @@ type dagSched struct {
 }
 
 // onDone resolves a terminal node's successors. A skipped node poisons its
-// successors (first poisoner wins the reason); every successor's indeg is
-// decremented and those that reach zero join the ready worklist.
-func (s *dagSched) onDone(name string, wasSkipped bool) {
-	s.pending--
-	for _, succ := range s.p.Successors[name] {
-		if wasSkipped && !s.skip[succ] {
-			s.skip[succ] = true
-			s.reason[succ] = fmt.Sprintf("upstream %q skipped", name)
+// successors (first poisoner wins the reason); every successor's unresolved
+// predecessor count is decremented and those that reach zero join the ready
+// worklist.
+func (s *dagScheduler) onDone(name string, wasSkipped bool) {
+	s.remaining--
+	for _, succ := range s.plan.Successors[name] {
+		if wasSkipped && !s.skipped[succ] {
+			s.skipped[succ] = true
+			s.skipReason[succ] = fmt.Sprintf("upstream %q skipped", name)
 		}
-		s.indeg[succ]--
-		if s.indeg[succ] == 0 {
+		s.unresolvedPreds[succ]--
+		if s.unresolvedPreds[succ] == 0 {
 			s.ready = append(s.ready, succ)
 		}
 	}
@@ -52,23 +68,24 @@ func (s *dagSched) onDone(name string, wasSkipped bool) {
 
 // decide reports whether name should be skipped, evaluating its when: predicate
 // against a stable snapshot when one is declared. A predicate error records
-// s.err, cancels the run, and reports skip=true to unwind the worklist quickly.
-func (s *dagSched) decide(name string) bool {
-	if s.skip[name] {
+// schedErr, cancels the run, and reports skip=true to unwind the worklist
+// quickly.
+func (s *dagScheduler) decide(name string) bool {
+	if s.skipped[name] {
 		return true
 	}
-	expr := s.p.When[name]
+	expr := s.plan.When[name]
 	if expr == "" {
 		return false
 	}
-	run, err := s.e.evalWhen(expr, s.baseline())
+	run, err := s.engine.evalWhen(expr, s.baseline())
 	if err != nil {
-		s.err = fmt.Errorf("flow %q: group %q: when: %w", s.p.Flow, name, err)
+		s.schedErr = fmt.Errorf("flow %q: group %q: when: %w", s.plan.Flow, name, err)
 		s.cancel()
 		return true
 	}
 	if !run {
-		s.reason[name] = "when"
+		s.skipReason[name] = "when"
 		return true
 	}
 	return false
@@ -77,17 +94,17 @@ func (s *dagSched) decide(name string) bool {
 // drainReady decides each ready node: skip (cascading synchronously) or launch.
 // A skip can make successors ready, which may themselves skip, so this loops
 // until the worklist is empty or a predicate error aborts the run.
-func (s *dagSched) drainReady() {
+func (s *dagScheduler) drainReady() {
 	for len(s.ready) > 0 {
 		name := s.ready[len(s.ready)-1]
 		s.ready = s.ready[:len(s.ready)-1]
 
 		if s.decide(name) {
-			if s.err != nil {
+			if s.schedErr != nil {
 				return
 			}
-			s.skip[name] = true
-			s.e.emitGroupSkipped(name, s.reason[name])
+			s.skipped[name] = true
+			s.engine.emitGroupSkipped(name, s.skipReason[name])
 			s.onDone(name, true)
 			continue
 		}
@@ -102,9 +119,9 @@ func (s *dagSched) drainReady() {
 // consumer cannot run on a producer's missing output.
 //
 // All skip decisions and bookkeeping live in this single scheduler goroutine
-// (the dagSched value); workers only run groups, publish outputs under snapMu,
-// and signal completion on doneCh. That keeps the conditional logic free of
-// additional synchronization.
+// (the dagScheduler value); workers only run groups, publish outputs under
+// snapMu, and signal completion on doneCh. That keeps the conditional logic
+// free of additional synchronization.
 func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow) error {
 	env := resolveEnvelope(flow, nil)
 
@@ -147,43 +164,43 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow
 		})
 	}
 
-	s := &dagSched{
-		e:        e,
-		p:        p,
-		indeg:    make(map[string]int, len(p.Members)),
-		skip:     make(map[string]bool, len(p.Members)),
-		reason:   make(map[string]string, len(p.Members)),
-		ready:    append(make([]string, 0, len(p.Members)), p.Roots...),
-		pending:  len(p.Members),
-		launch:   launch,
-		cancel:   cancel,
-		baseline: baseline,
+	s := &dagScheduler{
+		engine:          e,
+		plan:            p,
+		unresolvedPreds: make(map[string]int, len(p.Members)),
+		skipped:         make(map[string]bool, len(p.Members)),
+		skipReason:      make(map[string]string, len(p.Members)),
+		ready:           append(make([]string, 0, len(p.Members)), p.Roots...),
+		remaining:       len(p.Members),
+		launch:          launch,
+		cancel:          cancel,
+		baseline:        baseline,
 	}
 	for _, m := range p.Members {
-		s.indeg[m] = len(p.Predecessors[m])
+		s.unresolvedPreds[m] = len(p.Predecessors[m])
 	}
 
 	s.drainReady()
-	if s.err == nil {
+	if s.schedErr == nil {
 		e.runDAGLoop(gctx, doneCh, s)
 	}
 
-	if err := g.Wait(); err != nil && s.err == nil {
+	if err := g.Wait(); err != nil && s.schedErr == nil {
 		return err
 	}
-	return s.err
+	return s.schedErr
 }
 
 // runDAGLoop pumps completed groups from doneCh back into the scheduler until
 // every group has terminated (run or skipped), a predicate error aborts, or the
 // context is canceled.
-func (e *Engine) runDAGLoop(gctx context.Context, doneCh <-chan string, s *dagSched) {
-	for s.pending > 0 {
+func (e *Engine) runDAGLoop(gctx context.Context, doneCh <-chan string, s *dagScheduler) {
+	for s.remaining > 0 {
 		select {
 		case finished := <-doneCh:
 			s.onDone(finished, false)
 			s.drainReady()
-			if s.err != nil {
+			if s.schedErr != nil {
 				return
 			}
 		case <-gctx.Done():

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -196,7 +196,7 @@ func (e *Engine) runDAGLoop(gctx context.Context, doneCh <-chan string, s *dagSc
 // and a group.end event marking it skipped on the structured stream.
 func (e *Engine) emitGroupSkipped(name, reason string) {
 	e.log.Info("group skipped", "group", name, "reason", reason)
-	e.emitter.Emit(Event{Event: EventGroupEnd, Group: name, Status: StatusSkipped})
+	e.emitter.Emit(Event{Event: EventGroupEnd, Group: name, Status: StatusSkipped, Reason: reason})
 }
 
 func cloneSnapshot(m map[string]string) map[string]string {

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -66,29 +66,39 @@ func (s *dagScheduler) onDone(name string, wasSkipped bool) {
 	}
 }
 
-// decide reports whether name should be skipped, evaluating its when: predicate
-// against a stable snapshot when one is declared. A predicate error records
-// schedErr, cancels the run, and reports skip=true to unwind the worklist
-// quickly.
-func (s *dagScheduler) decide(name string) bool {
+// decision is the outcome of evaluating a ready node — three-valued so the
+// caller doesn't have to disambiguate skip-vs-error via a side-effect field.
+type decision int
+
+const (
+	decisionRun  decision = iota // launch the group on a worker goroutine
+	decisionSkip                 // skip (own when: falsey, or cascade-poisoned)
+	decisionErr                  // predicate render error recorded in schedErr
+)
+
+// decide evaluates a ready node. A cascade-poisoned node short-circuits to
+// decisionSkip. A node with a when: predicate evaluates it against a stable
+// snapshot; render errors record schedErr, cancel the run, and return
+// decisionErr so the worklist unwinds quickly.
+func (s *dagScheduler) decide(name string) decision {
 	if s.skipped[name] {
-		return true
+		return decisionSkip
 	}
 	expr := s.plan.When[name]
 	if expr == "" {
-		return false
+		return decisionRun
 	}
 	run, err := s.engine.evalWhen(expr, s.baseline())
 	if err != nil {
 		s.schedErr = fmt.Errorf("flow %q: group %q: when: %w", s.plan.Flow, name, err)
 		s.cancel()
-		return true
+		return decisionErr
 	}
 	if !run {
 		s.skipReason[name] = "when"
-		return true
+		return decisionSkip
 	}
-	return false
+	return decisionRun
 }
 
 // drainReady decides each ready node: skip (cascading synchronously) or launch.
@@ -99,16 +109,16 @@ func (s *dagScheduler) drainReady() {
 		name := s.ready[len(s.ready)-1]
 		s.ready = s.ready[:len(s.ready)-1]
 
-		if s.decide(name) {
-			if s.schedErr != nil {
-				return
-			}
+		switch s.decide(name) {
+		case decisionErr:
+			return
+		case decisionSkip:
 			s.skipped[name] = true
 			s.engine.emitGroupSkipped(name, s.skipReason[name])
 			s.onDone(name, true)
-			continue
+		case decisionRun:
+			s.launch(name)
 		}
-		s.launch(name)
 	}
 }
 
@@ -182,7 +192,7 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow
 
 	s.drainReady()
 	if s.schedErr == nil {
-		e.runDAGLoop(gctx, doneCh, s)
+		s.pump(gctx, doneCh)
 	}
 
 	if err := g.Wait(); err != nil && s.schedErr == nil {
@@ -191,10 +201,11 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow
 	return s.schedErr
 }
 
-// runDAGLoop pumps completed groups from doneCh back into the scheduler until
-// every group has terminated (run or skipped), a predicate error aborts, or the
-// context is canceled.
-func (e *Engine) runDAGLoop(gctx context.Context, doneCh <-chan string, s *dagScheduler) {
+// pump pumps completed groups from doneCh back into the scheduler until every
+// group has terminated (run or skipped), a predicate error aborts, or the
+// context is canceled. Lives on dagScheduler because every operation it
+// performs is scheduler-state mutation.
+func (s *dagScheduler) pump(gctx context.Context, doneCh <-chan string) {
 	for s.remaining > 0 {
 		select {
 		case finished := <-doneCh:

--- a/internal/engine/scheduler_dag_test.go
+++ b/internal/engine/scheduler_dag_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -60,6 +61,39 @@ func TestDAG_When_RunsWhenTrue(t *testing.T) {
 	for _, name := range []string{"build", "test", "deploy", "report"} {
 		assert.True(t, ran[name], "%s should run when test passes", name)
 	}
+}
+
+// TestDAG_When_DryRunStillEvaluatesPredicate covers gap #9 from the
+// self-review: in --dry-run, `when:` predicates still evaluate so the dry run
+// reveals the real control flow. A when:-skipped group emits status=skipped
+// (not dry-run) because the skip decision happens before runGroup is reached;
+// a normally-run group is the one that emits dry-run.
+func TestDAG_When_DryRunStillEvaluatesPredicate(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Version: config.SchemaVersion,
+		Groups: []config.Group{
+			{Name: "build", Command: "echo"},
+			{Name: "deploy", Command: "echo"},
+		},
+		Flows: map[string]config.Flow{
+			"ci": {Mode: config.ModeDAG, Run: []config.RunEntry{
+				{Group: "build"},
+				{Group: "deploy", When: "false"},
+			}},
+		},
+	}
+	var buf bytes.Buffer
+	e := New(cfg, WithRunner(&fakeRunner{}), WithDryRun(true), WithEmitter(NewJSONEmitter(&buf)))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	evs := decodeEvents(t, buf.Bytes())
+	// build is unconditional → dry-run swallows the actual command but still
+	// emits a group.end event with status=dry-run.
+	assert.Equal(t, StatusDryRun, statusOf(evs, "build"))
+	// deploy's when: rendered falsey → skip beats dry-run.
+	assert.Equal(t, StatusSkipped, statusOf(evs, "deploy"))
+	assert.Equal(t, "when", reasonOf(evs, "deploy"))
 }
 
 // TestDAG_When_RenderErrorAbortsFlow covers gap #7 from the self-review: a

--- a/internal/engine/scheduler_dag_test.go
+++ b/internal/engine/scheduler_dag_test.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// ranNames returns the set of group names the runner was invoked for.
+func ranNames(r *fakeRunner) map[string]bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]bool, len(r.calls))
+	for _, c := range r.calls {
+		name := c
+		if i := strings.IndexByte(c, ':'); i >= 0 {
+			name = c[:i]
+		}
+		out[name] = true
+	}
+	return out
+}
+
+func TestDAG_When_SkipsGroupAndCascades(t *testing.T) {
+	cfg, err := config.LoadConfig("../config/test-resources/config-dag-when.yml")
+	require.NoError(t, err)
+
+	// test outputs "fail" -> deploy.when (eq output(test) "pass") is false ->
+	// deploy is skipped -> report (consumes deploy's output) cascade-skips.
+	r := &fakeRunner{outputs: map[string]string{
+		"build": "built", "test": "fail",
+	}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	ran := ranNames(r)
+	assert.True(t, ran["build"], "build should run")
+	assert.True(t, ran["test"], "test should run")
+	assert.False(t, ran["deploy"], "deploy should be skipped (when false)")
+	assert.False(t, ran["report"], "report should cascade-skip (deploy skipped)")
+}
+
+func TestDAG_When_RunsWhenTrue(t *testing.T) {
+	cfg, err := config.LoadConfig("../config/test-resources/config-dag-when.yml")
+	require.NoError(t, err)
+
+	// test outputs "pass" -> deploy runs -> report consumes deploy output.
+	r := &fakeRunner{outputs: map[string]string{
+		"build": "built", "test": "pass", "deploy": "deploying",
+	}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	ran := ranNames(r)
+	for _, name := range []string{"build", "test", "deploy", "report"} {
+		assert.True(t, ran[name], "%s should run when test passes", name)
+	}
+}

--- a/internal/engine/scheduler_dag_test.go
+++ b/internal/engine/scheduler_dag_test.go
@@ -61,3 +61,33 @@ func TestDAG_When_RunsWhenTrue(t *testing.T) {
 		assert.True(t, ran[name], "%s should run when test passes", name)
 	}
 }
+
+// TestDAG_When_RenderErrorAbortsFlow covers gap #7 from the self-review: a
+// when: that parses cleanly but errors at render time must abort the flow
+// with the wrapped `flow %q: group %q: when: %w` message, cancel in-flight
+// work, and prevent dependents from running. Sprig's `fail` reliably returns
+// a render-time error.
+func TestDAG_When_RenderErrorAbortsFlow(t *testing.T) {
+	cfg := &config.Config{
+		Version: config.SchemaVersion,
+		Groups: []config.Group{
+			{Name: "build", Command: "echo"},
+			{Name: "deploy", Command: "echo"},
+		},
+		Flows: map[string]config.Flow{
+			"ci": {Mode: config.ModeDAG, Run: []config.RunEntry{
+				{Group: "build"},
+				{Group: "deploy", When: `{{ fail "boom" }}`},
+			}},
+		},
+	}
+	r := &fakeRunner{outputs: map[string]string{"build": "built"}}
+	e := New(cfg, WithRunner(r))
+	err := e.RunFlow(context.Background(), "ci")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `flow "ci"`)
+	assert.Contains(t, err.Error(), `group "deploy"`)
+	assert.Contains(t, err.Error(), "when:")
+	assert.Contains(t, err.Error(), "boom")
+	assert.False(t, ranNames(r)["deploy"], "deploy must not run after its when: errored")
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/template"
 )
 
 // Plan is the schedulable shape of a Flow.
@@ -15,6 +16,8 @@ import (
 // For step mode, Waves holds one entry per declared step (preserving order
 // and parallelism). For dag mode, Waves is nil and Predecessors / Successors
 // drive a Kahn-style scheduler; Roots is the initial ready set.
+// When carries the raw when: predicate for each group that declares one
+// (dag mode only; absent = unconditional).
 type Plan struct {
 	Flow         string
 	Mode         config.Mode
@@ -23,6 +26,7 @@ type Plan struct {
 	Predecessors map[string][]string // dag mode only
 	Successors   map[string][]string // dag mode only
 	Roots        []string            // dag mode only
+	When         map[string]string   // dag mode only: group -> when predicate (absent = unconditional)
 }
 
 // Build returns a Plan for the named flow.
@@ -52,30 +56,45 @@ func Build(cfg *config.Config, flowName string) (*Plan, error) {
 
 func buildDAGEdges(cfg *config.Config, flow *config.Flow, p *Plan) {
 	memberSet := make(map[string]struct{}, len(flow.Run))
-	for _, m := range flow.Run {
-		memberSet[m] = struct{}{}
+	for i := range flow.Run {
+		memberSet[flow.Run[i].Group] = struct{}{}
 	}
 	p.Predecessors = make(map[string][]string, len(flow.Run))
 	p.Successors = make(map[string][]string, len(flow.Run))
+	p.When = make(map[string]string)
 
-	for _, m := range flow.Run {
-		g := cfg.GroupByName(m)
+	for i := range flow.Run {
+		m := flow.Run[i].Group
+		if w := flow.Run[i].When; w != "" {
+			p.When[m] = w
+		}
 		seenPred := make(map[string]struct{})
-		// Refs cannot error here: NewConfig validated every template already.
-		refs, _ := config.ExtractRefs(g)
-		for _, ref := range refs {
+		addEdge := func(ref string) {
 			if _, in := memberSet[ref]; !in {
-				continue // ValidateReferences would have rejected this
+				return // ValidateReferences already rejected out-of-flow refs
 			}
 			if _, dup := seenPred[ref]; dup {
-				continue
+				return
 			}
 			seenPred[ref] = struct{}{}
 			p.Predecessors[m] = append(p.Predecessors[m], ref)
 			p.Successors[ref] = append(p.Successors[ref], m)
 		}
+		g := cfg.GroupByName(m)
+		// Refs cannot error here: NewConfig validated every template already.
+		refs, _ := config.ExtractRefs(g)
+		for _, ref := range refs {
+			addEdge(ref)
+		}
+		if w := flow.Run[i].When; w != "" {
+			whenRefs, _ := template.Refs(w)
+			for _, ref := range whenRefs {
+				addEdge(ref)
+			}
+		}
 	}
-	for _, m := range flow.Run {
+	for i := range flow.Run {
+		m := flow.Run[i].Group
 		if len(p.Predecessors[m]) == 0 {
 			p.Roots = append(p.Roots, m)
 		}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -65,7 +65,8 @@ func buildDAGEdges(cfg *config.Config, flow *config.Flow, p *Plan) {
 
 	for i := range flow.Run {
 		m := flow.Run[i].Group
-		if w := flow.Run[i].When; w != "" {
+		w := flow.Run[i].When
+		if w != "" {
 			p.When[m] = w
 		}
 		seenPred := make(map[string]struct{})
@@ -86,7 +87,7 @@ func buildDAGEdges(cfg *config.Config, flow *config.Flow, p *Plan) {
 		for _, ref := range refs {
 			addEdge(ref)
 		}
-		if w := flow.Run[i].When; w != "" {
+		if w != "" {
 			whenRefs, _ := template.Refs(w)
 			for _, ref := range whenRefs {
 				addEdge(ref)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,65 @@ flows:
 	p, err := Build(cfg, "f")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"a", "b"}, p.Roots)
+}
+
+func TestBuildDAGWhenCreatesEdge(t *testing.T) {
+	doc := `version: 2
+groups:
+  - {name: test, command: echo}
+  - {name: deploy, command: echo}
+flows:
+  ci:
+    mode: dag
+    run:
+      - test
+      - group: deploy
+        when: '{{ eq (output "test") "pass" }}'`
+	cfg, err := config.NewConfig([]byte(doc))
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	p, err := Build(cfg, "ci")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if got := p.Predecessors["deploy"]; len(got) != 1 || got[0] != "test" {
+		t.Fatalf("deploy predecessors = %v, want [test]", got)
+	}
+	if p.When["deploy"] != `{{ eq (output "test") "pass" }}` {
+		t.Fatalf("Plan.When[deploy] = %q, want the predicate", p.When["deploy"])
+	}
+	if len(p.Roots) != 1 || p.Roots[0] != "test" {
+		t.Fatalf("roots = %v, want [test]", p.Roots)
+	}
+}
+
+func TestBuildDAGBareStringsUnchanged(t *testing.T) {
+	// Regression guard: a no-when dag flow plans identically to legacy behavior.
+	doc := `version: 2
+groups:
+  - {name: a, command: echo}
+  - {name: b, command: 'echo {{ output "a" }}'}
+  - {name: c, command: echo}
+flows:
+  ci:
+    mode: dag
+    run: [a, b, c]`
+	cfg, err := config.NewConfig([]byte(doc))
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	p, err := Build(cfg, "ci")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(p.When) != 0 {
+		t.Fatalf("Plan.When = %v, want empty for no-when flow", p.When)
+	}
+	if got := p.Predecessors["b"]; len(got) != 1 || got[0] != "a" {
+		t.Fatalf("b predecessors = %v, want [a]", got)
+	}
+	if !reflect.DeepEqual(p.Roots, []string{"a", "c"}) {
+		t.Fatalf("roots = %v, want [a c]", p.Roots)
+	}
 }


### PR DESCRIPTION
Adds per-group `when:` conditionals to dag-mode flows, finishing the half of `when:` deferred in #18 (step-level shipped there; dag mode was deferred).

## What

A dag-mode `run:` entry may now be either a bare group name or a `{group, when}` map:

```yaml
flows:
  ci:
    mode: dag
    run:
      - build
      - test
      - group: deploy
        when: '{{ eq (output "test") "pass" }}'
      - report
```

- A falsey `when:` (`""`, `"false"`, `"0"`, `"no"`, `"off"`) **skips** the group.
- A skip **cascades**: every group downstream of it is skipped too (a consumer cannot run on a missing producer output). Cascade reason: `upstream "<name>" skipped`.
- A reference inside `when:` (`output "x"`) **creates a scheduling edge** — exactly like a command/param ref — so the producer always finishes before the predicate is evaluated, and the reference is cycle-checked at load time.
- Skipped groups emit a `group.end` event with `"status":"skipped"` and a new `"reason"` field. A skip is not a failure; the flow can still end `"ok"`.

## How

- **config:** polymorphic `RunEntry{Group, When}` with a string-or-map `UnmarshalYAML` (only `group`/`when` keys allowed); `Flow.Run` is now `[]RunEntry`.
- **validation:** `when:` references are validated and fed into the same acyclic-graph check as command refs.
- **planner:** `when:` refs become predecessor edges; predicates carried on `Plan.When`.
- **engine:** the dag scheduler evaluates `when:` and cascades skips entirely within its single scheduler goroutine — workers gain no new shared state, so it stays race-free.

## Backward compatibility

Bare-string `run:` lists parse and execute identically — the map form is purely additive, and a flow with no `when:` gains no new edges and behaves byte-for-byte as before (asserted by a planner regression test).

## Tests / verification

Table-driven tests across config/plan/engine (incl. a shared `config-dag-when.yml` fixture loaded by both config and engine tests), `go test -race ./...` and `golangci-lint run ./...` clean. End-to-end verified with the real binary for all-run, skip+cascade, root-`when:`, and double-referenced-group paths.

Docs updated: README features table, `docs/CONFIG.md`, `docs/FAQ.md`, `docs/USAGE.md`.