### PR TITLE
chore: Add Go Reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/quike/keepup/graph/badge.svg?token=IAD5CBIVTY)](https://codecov.io/gh/quike/keepup)
 [![go-score](https://goreportcard.com/badge/github.com/quike/keepup)](https://goreportcard.com/report/github.com/quike/keepup)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Reference](https://pkg.go.dev/badge/github.com/quike/keepup.svg)](https://pkg.go.dev/github.com/quike/keepup)
 
 Simple task runner.
 


### PR DESCRIPTION
Following https://pkg.go.dev/about#adding-a-package