### PR TITLE
feat: structured outputs (out template function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ shell unless you ask for it), and incremental re-runs via content-based caching.
 | **Groups + flows**       | Reusable command units composed into many named pipelines in one file — no duplication.                                     |
 | **Two scheduling modes** | `step` (explicit parallel waves with barriers) or `dag` (topological, inferred from `{{ output.X }}` data deps).            |
 | **Output piping**        | Pass one group's captured stdout into another via `{{ output "name" }}`, validated at load time.                            |
+| **Structured outputs**   | `{{ out "name" }}` returns a structured value (stdout, stderr, exit code, duration, status) for richer `when:` predicates. `output "name"` is unchanged. | dag + step |
 | **Templating**           | `command`/`params` are Go templates with [sprig](https://masterminds.github.io/sprig/): `{{ output "sha" \| trunc 7 }}`, `{{ env "CI" \| default "local" }}`. Legacy `{{ output.X }}` still works. |
 | **Caching**              | Per-group `cache: { reads, writes }` fingerprints inputs (hash or mtime) and skips unchanged work, replaying stored output. |
 | **Watch mode**           | `keepup watch` re-runs a flow on file changes (using each group's `cache.reads`); caching makes unaffected groups no-ops.   |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -191,6 +191,43 @@ Notes:
   computed name (e.g. `output (printf "g%d" 1)`) cannot be tracked and won't
   register as a dependency.
 
+### Structured access: `out "x"`
+
+`out "x"` returns a structured value for group `x`, exposing every fact the
+engine knows about that group's run. The traditional `output "x"` is unchanged
+— it still returns the group's trimmed merged stdout+stderr.
+
+Fields (Go-style capital case):
+
+| Field       | Type   | Notes                                                                             |
+| ----------- | ------ | --------------------------------------------------------------------------------- |
+| `Stdout`    | string | stdout only                                                                       |
+| `Stderr`    | string | stderr only                                                                       |
+| `Output`    | string | chronologically merged stdout+stderr; `output "x"` returns its trimmed form       |
+| `ExitCode`  | int    | 0 for ok; non-zero values appear only once soft-fail ships                        |
+| `DurationMs`| int64  | wall-clock milliseconds; 0 for skipped and cache-hit groups                       |
+| `Status`    | string | one of `"ok"`, `"skipped"`, `"cached"`, `"dry-run"`                               |
+
+Examples:
+
+```yaml
+when: '{{ eq (out "test").Status "ok" }}'
+when: '{{ gt (out "probe").DurationMs 500 }}'
+when: '{{ contains "WARNING" (out "lint").Stderr }}'
+```
+
+Existing templates using `output "x"` work byte-for-byte identically; only
+opt into `out` where you want structured access.
+
+**Upgrading from earlier versions:** the cache fingerprint format bumped
+once, so the first run after upgrade rebuilds every cached step. Steady-state
+cache hits return on the next run.
+
+**Skip semantics:** `when:`-skipped groups, cascade-skipped dependents, and
+`skip-if:`-skipped groups are all stored with `Status: "skipped"` and empty
+`Output`. (Previously skip-if'd groups exposed a stale cached `Output` —
+that's no longer the case.)
+
 ### Gating: `skip-if` and `require`
 
 Two optional predicates let a group decide whether it should run. Both are

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -246,7 +246,7 @@ groups:
 | Field     | Meaning                                   | On match                                                                                                |
 | --------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `require` | Precondition that must hold               | Non-zero exit → the group (and its flow) fails with a clear error.                                      |
-| `skip-if` | Condition under which work is unnecessary | Exit 0 → the group is skipped; its output is the last cached value if `cache:` is set, otherwise empty. |
+| `skip-if` | Condition under which work is unnecessary | Exit 0 → the group is skipped and stored with `Status: "skipped"` and empty `Output` (see **Structured access** below).                |
 
 Evaluation order per group: `require` → `skip-if` → `cache` → run. In
 `--dry-run`, `require` and `skip-if` shell predicates are **not** evaluated

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -249,8 +249,9 @@ groups:
 | `skip-if` | Condition under which work is unnecessary | Exit 0 → the group is skipped; its output is the last cached value if `cache:` is set, otherwise empty. |
 
 Evaluation order per group: `require` → `skip-if` → `cache` → run. In
-`--dry-run`, predicates are **not** evaluated — keepup only logs what it would
-do.
+`--dry-run`, `require` and `skip-if` shell predicates are **not** evaluated
+(no shells are spawned). `when:` template predicates are still evaluated so
+dry-run reveals real control flow.
 
 ### Caching
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -188,6 +188,39 @@ It still trims. `output` returns the referenced group's stdout with
 surrounding whitespace removed, exactly like the original expander — so a
 producer printing `banana\n` substitutes as `banana`.
 
+### When do I use `output` vs `out`?
+
+`output "x"` returns the trimmed merged stdout+stderr as a string — use it
+when you want to pipe through sprig string functions or embed in a
+command/param. `out "x"` returns a structured value: use it when you want to
+read a specific field (`.ExitCode`, `.DurationMs`, `.Stderr`, `.Status`). Both
+are fully supported; `output` is unchanged from earlier versions.
+
+### Why does `(out "x").ExitCode` have a capital `E`?
+
+`out` returns a Go struct, and Go templates access struct fields case-sensitively
+using the Go field name. Use `.Stdout`, `.Stderr`, `.Output`, `.ExitCode`,
+`.DurationMs`, `.Status` (all capital first letter).
+
+### Will my existing templates break?
+
+No. `output "x"` keeps its exact contract — same trimmed string, same sprig
+pipe support. Two changes worth flagging:
+
+- The cache fingerprint format bumped once, so the first run after upgrade
+  rebuilds every cached step. Steady-state cache hits return on the next run.
+- A `skip-if:`-skipped group used to expose its prior cached output through
+  `{{ output "x" }}`; it now exposes empty string. Templates that read a
+  skipped producer's output now see `""`. Use `(out "x").Status == "skipped"`
+  to branch on skip explicitly.
+
+### Does `--dry-run` interact with structured outputs?
+
+Yes — in dry-run, every group that would run is instead stored with
+`Status: "dry-run"` (no actual command executes, but `when:` predicates still
+evaluate against env/outputs to surface the real control flow). A dry-run
+group's `Output` is empty.
+
 ---
 
 ## Execution

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -392,8 +392,11 @@ string. Downstream references always resolve to _something_, never an error.
 
 ### Do predicates and caching run during `--dry-run`?
 
-No. Dry-run logs what _would_ happen and evaluates neither predicates nor the
-cache, so it never touches disk or spawns shells.
+It depends on the predicate type. `when:` template predicates **do** evaluate
+— they have no side effects and dry-run uses the results to reveal real control
+flow (which groups would skip, which would cascade). `require` and `skip-if`
+shell predicates do **not** run — no shells are spawned and the cache is not
+consulted, so dry-run never touches disk.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -216,6 +216,42 @@ When the predicate is falsey (e.g. `DEPLOY` unset in an env-gated flow),
 
 The flow still ends `"status":"ok"` — a skip is not an error.
 
+## Gating on a previous group's exit status, duration, or skip
+
+Structured outputs (`out "x"`) let you branch on any fact the engine knows
+about a prior group:
+
+```yaml
+groups:
+  - { name: probe, command: ./probe.sh }
+  - { name: thorough-check, command: ./thorough.sh }
+
+flows:
+  diagnostic:
+    mode: dag
+    run:
+      - probe
+      - group: thorough-check
+        when: '{{ gt (out "probe").DurationMs 500 }}'
+```
+
+`thorough-check` runs only when the probe took longer than half a second —
+useful for adaptive flows that fall back to expensive checks only when a
+cheap probe is inconclusive.
+
+To branch on whether a sibling was skipped (rather than ran):
+
+```yaml
+when: '{{ eq (out "deploy").Status "skipped" }}'
+```
+
+When `out "x"` references a group not listed in the flow's `run:`, config
+validation rejects it at load (identical rule to `output "x"`).
+
+`output "x"` is unchanged — it still returns the trimmed merged stdout+stderr
+and works in all sprig pipes. Use `out "x"` only when you need a specific
+field like `.Status`, `.DurationMs`, or `.Stderr`.
+
 ## More
 
 - [Configuration](CONFIG.md) — every field, defaults, semantics

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -14,15 +14,16 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 )
 
 // Entry is a persisted cache record for one group.
 type Entry struct {
-	Fingerprint string    `json:"fingerprint"`
-	Output      string    `json:"output"`
-	Command     string    `json:"command"`
-	Params      []string  `json:"params"`
-	UpdatedAt   time.Time `json:"updatedAt"`
+	Fingerprint string           `json:"fingerprint"`
+	Result      result.RunResult `json:"result"`
+	Command     string           `json:"command"`
+	Params      []string         `json:"params"`
+	UpdatedAt   time.Time        `json:"updatedAt"`
 }
 
 // Store loads and saves cache entries keyed by group name.
@@ -39,7 +40,7 @@ func Compute(spec *config.Cache, command string, params []string) (string, error
 	h := sha256.New()
 	// Salt with command/params/method so a changed command busts the cache
 	// even when inputs are identical.
-	fmt.Fprintf(h, "v1\x00%s\x00%s\x00", spec.Method, command)
+	fmt.Fprintf(h, "v2\x00%s\x00%s\x00", spec.Method, command)
 	for _, p := range params {
 		fmt.Fprintf(h, "%s\x01", p)
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 )
 
 func writeFile(t *testing.T, path, content string) {
@@ -161,7 +163,7 @@ func TestFileStore_RoundTrip(t *testing.T) {
 
 	entry := &Entry{
 		Fingerprint: "sha256:abc",
-		Output:      "done\n",
+		Result:      result.RunResult{Output: "done\n"},
 		Command:     "go",
 		Params:      []string{"build"},
 		UpdatedAt:   time.Now(),
@@ -172,7 +174,7 @@ func TestFileStore_RoundTrip(t *testing.T) {
 		got, ok := store.Load("build")
 		require.True(t, ok)
 		assert.Equal(t, "sha256:abc", got.Fingerprint)
-		assert.Equal(t, "done\n", got.Output)
+		assert.Equal(t, "done\n", got.Result.Output)
 	})
 
 	t.Run("group name with slashes is sanitized", func(t *testing.T) {
@@ -191,4 +193,49 @@ func TestFileStore_CorruptEntryIsMiss(t *testing.T) {
 	store := NewFileStore(cdir)
 	_, ok := store.Load("build")
 	assert.False(t, ok)
+}
+
+// TestEntryRoundTripWithRunResult verifies that a full RunResult is
+// persisted and restored faithfully through the FileStore.
+func TestEntryRoundTripWithRunResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s := NewFileStore(dir)
+	want := &Entry{
+		Fingerprint: "sha256:abc",
+		Result: result.RunResult{
+			Stdout:     "hi\n",
+			Stderr:     "warn\n",
+			Output:     "hi\nwarn\n",
+			ExitCode:   0,
+			DurationMs: 12,
+			Status:     "ok",
+		},
+		Command:   "echo",
+		Params:    []string{"hi"},
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, s.Save("g", want))
+	got, ok := s.Load("g")
+	require.True(t, ok)
+	assert.Equal(t, want.Result, got.Result)
+	assert.Equal(t, want.Fingerprint, got.Fingerprint)
+}
+
+// TestComputeUsesV2Salt confirms the fingerprint salt is v2, which
+// ensures every v1 cached fingerprint becomes a miss on first run after
+// the upgrade.
+func TestComputeUsesV2Salt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o600))
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "f.txt")}}
+	fp, err := Compute(spec, "echo", []string{"a"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(fp, "sha256:"))
+
+	// Determinism: identical inputs produce identical fingerprints.
+	fp2, err := Compute(spec, "echo", []string{"a"})
+	require.NoError(t, err)
+	assert.Equal(t, fp, fp2)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -895,3 +895,30 @@ func TestLoadOutStructFixture(t *testing.T) {
 	assert.Equal(t, "false", f.Run[1].When)
 	assert.Equal(t, "report", f.Run[2].Group)
 }
+
+// TestLoadOutStructFieldsFixture confirms the per-field structured-outputs
+// fixture loads cleanly — exercising the refs walker on every (out "x").<Field>
+// form in a `when:` predicate.
+func TestLoadOutStructFieldsFixture(t *testing.T) {
+	t.Parallel()
+	cfg, err := LoadConfig("./test-resources/config-out-struct-fields.yml")
+	require.NoError(t, err)
+	f := cfg.Flows["all"]
+	require.Equal(t, ModeDAG, f.Mode)
+	require.Len(t, f.Run, 7)
+	// Each consumer references a different RunResult field; assert each
+	// when: was parsed onto the right entry.
+	wantWhen := map[string]string{
+		"consume-stdout":   `{{ ne (out "producer").Stdout "" }}`,
+		"consume-stderr":   `{{ eq (out "producer").Stderr "" }}`,
+		"consume-output":   `{{ contains "PROD" (out "producer").Output }}`,
+		"consume-exit":     `{{ eq (out "producer").ExitCode 0 }}`,
+		"consume-duration": `{{ ge (out "producer").DurationMs 0 }}`,
+		"consume-status":   `{{ eq (out "producer").Status "ok" }}`,
+	}
+	for _, entry := range f.Run {
+		if want, ok := wantWhen[entry.Group]; ok {
+			assert.Equal(t, want, entry.When, "when: for %s", entry.Group)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -879,3 +879,19 @@ func TestFlowMembersDAGFromRunEntries(t *testing.T) {
 	}
 	assert.Equal(t, []string{"build", "deploy"}, f.Members())
 }
+
+// TestLoadOutStructFixture confirms the shared structured-outputs fixture
+// loads cleanly and produces the expected dag-run shape — paired with the
+// engine-side integration test in internal/engine/out_struct_test.go.
+func TestLoadOutStructFixture(t *testing.T) {
+	t.Parallel()
+	cfg, err := LoadConfig("./test-resources/config-out-struct.yml")
+	require.NoError(t, err)
+	f := cfg.Flows["ci"]
+	assert.Equal(t, ModeDAG, f.Mode)
+	require.Len(t, f.Run, 3)
+	assert.Equal(t, "build", f.Run[0].Group)
+	assert.Equal(t, "lint", f.Run[1].Group)
+	assert.Equal(t, "false", f.Run[1].When)
+	assert.Equal(t, "report", f.Run[2].Group)
+}

--- a/internal/config/test-resources/config-out-struct-fields.yml
+++ b/internal/config/test-resources/config-out-struct-fields.yml
@@ -1,0 +1,37 @@
+---
+# Exercises every RunResult field through a `when:` predicate so a regression
+# at any layer (engine → outputstore → template → refs) shows up as a missed
+# consumer run. The producer is a normal `ok` run; each consumer reads one
+# field of `(out "producer")` and renders truthy against the producer's actual
+# RunResult, so all six consumers should execute.
+version: 2
+
+default: all
+
+groups:
+  - { name: producer, command: echo, params: ["PRODUCED"] }
+  - { name: consume-stdout, command: echo, params: ["seen-stdout"] }
+  - { name: consume-stderr, command: echo, params: ["seen-stderr"] }
+  - { name: consume-output, command: echo, params: ["seen-output"] }
+  - { name: consume-exit, command: echo, params: ["seen-exit"] }
+  - { name: consume-duration, command: echo, params: ["seen-duration"] }
+  - { name: consume-status, command: echo, params: ["seen-status"] }
+
+flows:
+  all:
+    description: "One consumer per RunResult field, gated on (out \"producer\").<Field>"
+    mode: dag
+    run:
+      - producer
+      - group: consume-stdout
+        when: '{{ ne (out "producer").Stdout "" }}'
+      - group: consume-stderr
+        when: '{{ eq (out "producer").Stderr "" }}'
+      - group: consume-output
+        when: '{{ contains "PROD" (out "producer").Output }}'
+      - group: consume-exit
+        when: '{{ eq (out "producer").ExitCode 0 }}'
+      - group: consume-duration
+        when: '{{ ge (out "producer").DurationMs 0 }}'
+      - group: consume-status
+        when: '{{ eq (out "producer").Status "ok" }}'

--- a/internal/config/test-resources/config-out-struct.yml
+++ b/internal/config/test-resources/config-out-struct.yml
@@ -1,0 +1,23 @@
+---
+# Exercises every status a RunResult can carry through dag execution:
+#   build  -> ok (ran successfully)
+#   lint   -> skipped via when: false
+#   report -> cascade-skipped (consumes lint's output)
+version: 2
+
+default: ci
+
+groups:
+  - { name: build, command: echo, params: ["built"] }
+  - { name: lint, command: echo, params: ["lint output"] }
+  - { name: report, command: echo, params: ['{{ output "lint" }}'] }
+
+flows:
+  ci:
+    description: "Exercises ok / skipped / cascade-skipped statuses"
+    mode: dag
+    run:
+      - build
+      - group: lint
+        when: "false"
+      - report

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/logger"
 	"github.com/quike/keepup/internal/plan"
+	"github.com/quike/keepup/internal/result"
 	"github.com/quike/keepup/internal/template"
 )
 
@@ -36,6 +37,17 @@ type Engine struct {
 // DefaultRetryBackoff is the base delay between retry attempts; the delay for
 // attempt N is DefaultRetryBackoff * N.
 const DefaultRetryBackoff = 250 * time.Millisecond
+
+// RunResult.Status values stored in the OutputStore. These are the
+// model-layer statuses set on `result.RunResult` (distinct from the
+// observability-layer event statuses in events.go); "ok", "skipped",
+// "dry-run" coincide by value, while "cached" is unique to results.
+const (
+	resultStatusOK      = "ok"
+	resultStatusCached  = "cached"
+	resultStatusSkipped = "skipped"
+	resultStatusDryRun  = "dry-run"
+)
 
 // Option configures an Engine.
 type Option func(*Engine)
@@ -177,7 +189,7 @@ func resolveEnvelope(flow *config.Flow, step *config.Step) envelope {
 // Skipped or cache-hit groups still publish an output value so downstream
 // {{ output.X }} references resolve. The command run (only) is wrapped with the
 // envelope's per-attempt timeout and bounded retries.
-func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]string, env envelope) (err error) {
+func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map[string]result.RunResult, env envelope) (err error) {
 	start := time.Now()
 	e.emitter.Emit(Event{Event: EventGroupStart, Group: group.Name})
 	status := StatusOK
@@ -214,6 +226,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	if e.dryRun {
 		e.log.Info("[dry-run] would run",
 			"group", g.Name, "command", g.Command, "params", expanded, "shell", g.UseShell())
+		e.outputs.Set(g.Name, result.RunResult{Status: resultStatusDryRun})
 		status = StatusDryRun
 		return nil
 	}
@@ -226,8 +239,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	if g.SkipIf != "" {
 		if err = e.prober.Probe(ctx, g.SkipIf, e.cfg.Env); err == nil {
-			out := e.cachedOutput(&g)
-			e.outputs.Set(g.Name, out)
+			e.outputs.Set(g.Name, result.RunResult{Status: resultStatusSkipped})
 			e.log.Info("group skipped", "group", g.Name, "reason", "skip-if", "predicate", g.SkipIf)
 			status = StatusSkipped
 			return nil
@@ -235,7 +247,9 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	}
 
 	if fp, hit := e.cacheLookup(&g, expanded); hit {
-		e.outputs.Set(g.Name, fp.Output)
+		cached := fp.Result
+		cached.Status = resultStatusCached
+		e.outputs.Set(g.Name, cached)
 		e.log.Info("cache hit", "group", g.Name, "fingerprint", fp.Fingerprint)
 		status = StatusCacheHit
 		return nil
@@ -244,22 +258,23 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	e.log.Info("running group", "group", g.Name, "command", g.Command, "params", expanded)
 	out, err := e.execWithEnvelope(ctx, &g, expanded, env)
 	if err != nil {
-		e.log.Error("group failed", "group", g.Name, "err", err.Error(), "output", out)
+		e.log.Error("group failed", "group", g.Name, "err", err.Error(), "output", out.Output)
 		return err
 	}
-	e.log.Trace("group output", "group", g.Name, "output", out)
+	e.log.Trace("group output", "group", g.Name, "output", out.Output)
+	out.Status = resultStatusOK
 	e.outputs.Set(g.Name, out)
-	e.cacheStore(&g, expanded, out)
+	e.cacheStore(&g, expanded, &out)
 	return nil
 }
 
 // execWithEnvelope runs the group's command, applying a per-attempt timeout and
 // retrying up to env.retries additional times on failure. Backoff between
 // attempts respects ctx cancellation.
-func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, params []string, env envelope) (string, error) {
+func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, params []string, env envelope) (result.RunResult, error) {
 	attempts := 1 + env.retries
 	var (
-		out string
+		out result.RunResult
 		err error
 	)
 	for attempt := 1; attempt <= attempts; attempt++ {
@@ -308,7 +323,7 @@ func (e *Engine) cacheLookup(group *config.Group, params []string) (*cache.Entry
 }
 
 // cacheStore persists a fresh cache entry after a successful run.
-func (e *Engine) cacheStore(group *config.Group, params []string, out string) {
+func (e *Engine) cacheStore(group *config.Group, params []string, out *result.RunResult) {
 	if e.noCache || group.Cache == nil {
 		return
 	}
@@ -319,7 +334,7 @@ func (e *Engine) cacheStore(group *config.Group, params []string, out string) {
 	}
 	entry := &cache.Entry{
 		Fingerprint: fp,
-		Output:      out,
+		Result:      *out,
 		Command:     group.Command,
 		Params:      params,
 		UpdatedAt:   time.Now(),
@@ -327,16 +342,4 @@ func (e *Engine) cacheStore(group *config.Group, params []string, out string) {
 	if err := e.cache.Save(group.Name, entry); err != nil {
 		e.log.Warn("cache save failed", "group", group.Name, "err", err.Error())
 	}
-}
-
-// cachedOutput returns the last cached output for a group when available, so a
-// skipped group can still satisfy downstream references. Returns "" otherwise.
-func (e *Engine) cachedOutput(group *config.Group) string {
-	if e.noCache || group.Cache == nil {
-		return ""
-	}
-	if entry, ok := e.cache.Load(group.Name); ok {
-		return entry.Output
-	}
-	return ""
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -38,17 +38,6 @@ type Engine struct {
 // attempt N is DefaultRetryBackoff * N.
 const DefaultRetryBackoff = 250 * time.Millisecond
 
-// RunResult.Status values stored in the OutputStore. These are the
-// model-layer statuses set on `result.RunResult` (distinct from the
-// observability-layer event statuses in events.go); "ok", "skipped",
-// "dry-run" coincide by value, while "cached" is unique to results.
-const (
-	resultStatusOK      = "ok"
-	resultStatusCached  = "cached"
-	resultStatusSkipped = "skipped"
-	resultStatusDryRun  = "dry-run"
-)
-
 // Option configures an Engine.
 type Option func(*Engine)
 
@@ -226,7 +215,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	if e.dryRun {
 		e.log.Info("[dry-run] would run",
 			"group", g.Name, "command", g.Command, "params", expanded, "shell", g.UseShell())
-		e.outputs.Set(g.Name, result.RunResult{Status: resultStatusDryRun})
+		e.outputs.Set(g.Name, result.RunResult{Status: result.StatusDryRun})
 		status = StatusDryRun
 		return nil
 	}
@@ -239,7 +228,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	if g.SkipIf != "" {
 		if err = e.prober.Probe(ctx, g.SkipIf, e.cfg.Env); err == nil {
-			e.outputs.Set(g.Name, result.RunResult{Status: resultStatusSkipped})
+			e.outputs.Set(g.Name, result.RunResult{Status: result.StatusSkipped})
 			e.log.Info("group skipped", "group", g.Name, "reason", "skip-if", "predicate", g.SkipIf)
 			status = StatusSkipped
 			return nil
@@ -248,7 +237,7 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	if fp, hit := e.cacheLookup(&g, expanded); hit {
 		cached := fp.Result
-		cached.Status = resultStatusCached
+		cached.Status = result.StatusCached
 		e.outputs.Set(g.Name, cached)
 		e.log.Info("cache hit", "group", g.Name, "fingerprint", fp.Fingerprint)
 		status = StatusCacheHit
@@ -262,7 +251,8 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 		return err
 	}
 	e.log.Trace("group output", "group", g.Name, "output", out.Output)
-	out.Status = resultStatusOK
+	// Runner sets Status to result.StatusOK on success; trust it so a future
+	// soft-fail Runner can return Status:"failed" without engine clobbering.
 	e.outputs.Set(g.Name, out)
 	e.cacheStore(&g, expanded, &out)
 	return nil

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 	"github.com/quike/keepup/internal/template"
 )
 
@@ -24,21 +25,28 @@ type fakeRunner struct {
 	delays  map[string]time.Duration
 }
 
-func (f *fakeRunner) Run(ctx context.Context, g *config.Group, params []string, _ map[string]string) (string, error) {
+func (f *fakeRunner) Run(ctx context.Context, g *config.Group, params []string, _ map[string]string) (result.RunResult, error) {
 	if d := f.delays[g.Name]; d > 0 {
 		select {
 		case <-time.After(d):
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return result.RunResult{}, ctx.Err()
 		}
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, g.Name+":"+strings.Join(params, ","))
-	if err, ok := f.errs[g.Name]; ok {
-		return f.outputs[g.Name], err
+	stdout := f.outputs[g.Name]
+	rr := result.RunResult{
+		Stdout: stdout,
+		Output: stdout,
+		Status: "ok",
 	}
-	return f.outputs[g.Name], nil
+	if err, ok := f.errs[g.Name]; ok {
+		rr.ExitCode = 1
+		return rr, err
+	}
+	return rr, nil
 }
 
 // stepFlowCfg builds a config with a single step-mode flow over the given groups.
@@ -79,7 +87,7 @@ func TestEngine_StepFlow_TwoGroupsInOneStep(t *testing.T) {
 
 	require.NoError(t, e.RunFlow(context.Background(), "f"))
 	got, _ := e.Outputs().Get("a")
-	assert.Equal(t, "A\n", got)
+	assert.Equal(t, "A\n", got.Output)
 }
 
 func TestEngine_StepFlow_RunnerErrorPropagatesWrapped(t *testing.T) {
@@ -189,10 +197,10 @@ type concurrencyRunner struct {
 	after  func()
 }
 
-func (c *concurrencyRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (string, error) {
+func (c *concurrencyRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (result.RunResult, error) {
 	c.before()
 	defer c.after()
-	return "", nil
+	return result.RunResult{Status: "ok"}, nil
 }
 
 func TestEngine_DAGFlow_ProducerThenConsumer(t *testing.T) {
@@ -233,7 +241,7 @@ func TestEngine_Options(t *testing.T) {
 
 	t.Run("WithOutputStore is honored", func(t *testing.T) {
 		custom := NewMemoryOutputStore()
-		custom.Set("seed", "preloaded")
+		custom.Set("seed", result.RunResult{Output: "preloaded", Status: "ok"})
 		e := New(cfg, WithOutputStore(custom), WithRunner(&fakeRunner{}))
 		assert.Same(t, custom, e.Outputs())
 	})
@@ -284,11 +292,11 @@ func (c *captureLogger) Trace(s string, _ ...any) { c.add("T:" + s) }
 func TestOutputStore_Snapshot(t *testing.T) {
 	t.Parallel()
 	s := NewMemoryOutputStore()
-	s.Set("a", "1")
-	s.Set("b", "2")
+	s.Set("a", result.RunResult{Output: "1", Status: "ok"})
+	s.Set("b", result.RunResult{Output: "2", Status: "ok"})
 	snap := s.Snapshot()
-	assert.Equal(t, "1", snap["a"])
-	snap["a"] = "mutated"
+	assert.Equal(t, "1", snap["a"].Output)
+	snap["a"] = result.RunResult{Output: "mutated"}
 	v, _ := s.Get("a")
-	assert.Equal(t, "1", v)
+	assert.Equal(t, "1", v.Output)
 }

--- a/internal/engine/envelope_test.go
+++ b/internal/engine/envelope_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 )
 
 // flakyRunner fails the first failUntil-1 attempts, then succeeds.
@@ -20,22 +21,22 @@ type flakyRunner struct {
 	output    string
 }
 
-func (r *flakyRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (string, error) {
+func (r *flakyRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (result.RunResult, error) {
 	n := atomic.AddInt32(&r.calls, 1)
 	if n <= r.failUntil {
-		return "", errors.New("transient failure")
+		return result.RunResult{ExitCode: 1}, errors.New("transient failure")
 	}
-	return r.output, nil
+	return result.RunResult{Stdout: r.output, Output: r.output, Status: "ok"}, nil
 }
 
 // blockingRunner blocks until ctx is done, then returns ctx.Err() — used to
 // exercise timeouts.
 type blockingRunner struct{ calls int32 }
 
-func (r *blockingRunner) Run(ctx context.Context, _ *config.Group, _ []string, _ map[string]string) (string, error) {
+func (r *blockingRunner) Run(ctx context.Context, _ *config.Group, _ []string, _ map[string]string) (result.RunResult, error) {
 	atomic.AddInt32(&r.calls, 1)
 	<-ctx.Done()
-	return "", ctx.Err()
+	return result.RunResult{}, ctx.Err()
 }
 
 func TestResolveEnvelope(t *testing.T) {
@@ -77,7 +78,7 @@ func TestEngine_Retries_SucceedAfterFailures(t *testing.T) {
 	require.NoError(t, e.RunFlow(context.Background(), "f"))
 	assert.Equal(t, int32(3), atomic.LoadInt32(&r.calls), "should retry until the 3rd attempt succeeds")
 	v, _ := e.Outputs().Get("a")
-	assert.Equal(t, "ok", v)
+	assert.Equal(t, "ok", v.Output)
 }
 
 func TestEngine_Retries_ExhaustedFails(t *testing.T) {

--- a/internal/engine/gating_cache_test.go
+++ b/internal/engine/gating_cache_test.go
@@ -77,10 +77,11 @@ func TestEngine_SkipIf(t *testing.T) {
 
 		require.NoError(t, e.RunFlow(context.Background(), "f"))
 		assert.Empty(t, r.calls, "runner must not be called when skip-if passes")
-		// Skipped group still publishes an (empty) output.
+		// Skipped group still publishes a (status=skipped) result.
 		v, ok := e.Outputs().Get("a")
 		assert.True(t, ok)
-		assert.Equal(t, "", v)
+		assert.Equal(t, "", v.Output)
+		assert.Equal(t, "skipped", v.Status)
 	})
 
 	t.Run("predicate fails → group runs", func(t *testing.T) {
@@ -123,7 +124,8 @@ func TestEngine_Cache_MissThenHit(t *testing.T) {
 	require.NoError(t, e2.RunFlow(context.Background(), "f"))
 	assert.Empty(t, r2.calls, "cache hit must skip the runner")
 	v, _ := e2.Outputs().Get("build")
-	assert.Equal(t, "compiled\n", v, "cache hit replays the original output")
+	assert.Equal(t, "compiled\n", v.Output, "cache hit replays the original output")
+	assert.Equal(t, "cached", v.Status)
 }
 
 func TestEngine_Cache_InputChangeBusts(t *testing.T) {

--- a/internal/engine/out_struct_test.go
+++ b/internal/engine/out_struct_test.go
@@ -52,3 +52,46 @@ func TestEngine_OutStruct_AllStatuses(t *testing.T) {
 	require.Equal(t, EventFlowEnd, flowEnd.Event, "flow.end must be emitted")
 	assert.Equal(t, StatusOK, flowEnd.Status, "skip cascade must not turn flow.end into a failure")
 }
+
+// TestEngine_OutStruct_FieldsThreadEndToEnd asserts that every RunResult field
+// is observable from a `when:` template predicate through the full
+// engine → outputstore → template → refs pipeline. A producer runs once, then
+// six consumers each gate on a different field of (out "producer").Field;
+// every predicate is constructed to render truthy against the producer's
+// actual RunResult so every consumer should run. If any layer of the pipeline
+// truncates, drops, or mistypes a field, the corresponding consumer will not
+// run and the test will fail with a precise pointer at which field broke.
+func TestEngine_OutStruct_FieldsThreadEndToEnd(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-out-struct-fields.yml")
+	require.NoError(t, err)
+
+	// fakeRunner mirrors the user-provided string into Stdout and Output and
+	// leaves Stderr empty (matching ShellRunner's three-buffer semantics for
+	// commands that only write to stdout). ExitCode=0, DurationMs=0, Status=ok.
+	r := &fakeRunner{outputs: map[string]string{"producer": "PRODUCED"}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "all"))
+
+	store := e.Outputs()
+	consumers := []string{
+		"consume-stdout",
+		"consume-stderr",
+		"consume-output",
+		"consume-exit",
+		"consume-duration",
+		"consume-status",
+	}
+	for _, name := range consumers {
+		rr, ok := store.Get(name)
+		require.True(t, ok, "%s must be stored", name)
+		assert.Equal(t, "ok", rr.Status,
+			"%s should have run (its when: predicate over (out \"producer\").<Field> must render truthy)", name)
+	}
+
+	// Producer must also have run successfully.
+	producerRR, ok := store.Get("producer")
+	require.True(t, ok)
+	assert.Equal(t, "ok", producerRR.Status)
+	assert.Equal(t, "PRODUCED", producerRR.Output)
+}

--- a/internal/engine/out_struct_test.go
+++ b/internal/engine/out_struct_test.go
@@ -1,0 +1,54 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+)
+
+// TestEngine_OutStruct_AllStatuses runs the shared structured-outputs fixture
+// end-to-end against the engine and asserts every group's stored RunResult
+// carries the expected Status. It also confirms the event stream emits
+// flow.end with Status "ok" — a skip cascade is not a failure.
+func TestEngine_OutStruct_AllStatuses(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-out-struct.yml")
+	require.NoError(t, err)
+
+	r := &fakeRunner{outputs: map[string]string{"build": "built"}}
+	var buf bytes.Buffer
+	e := New(cfg, WithRunner(r), WithEmitter(NewJSONEmitter(&buf)))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	store := e.Outputs()
+
+	buildRR, ok := store.Get("build")
+	require.True(t, ok, "build must be stored")
+	assert.Equal(t, "ok", buildRR.Status, "build ran successfully")
+	assert.Equal(t, "built", buildRR.Output, "build captured its stdout")
+
+	lintRR, ok := store.Get("lint")
+	require.True(t, ok, "directly when:-skipped lint must be stored")
+	assert.Equal(t, "skipped", lintRR.Status)
+	assert.Empty(t, lintRR.Output, "skipped group has no captured output")
+
+	reportRR, ok := store.Get("report")
+	require.True(t, ok, "cascade-skipped report must be stored")
+	assert.Equal(t, "skipped", reportRR.Status)
+
+	// Event stream confirms the flow ends ok — a skip cascade is not a failure.
+	evs := decodeEvents(t, buf.Bytes())
+	var flowEnd Event
+	for i := range evs {
+		if evs[i].Event == EventFlowEnd {
+			flowEnd = evs[i]
+		}
+	}
+	require.Equal(t, EventFlowEnd, flowEnd.Event, "flow.end must be emitted")
+	assert.Equal(t, StatusOK, flowEnd.Status, "skip cascade must not turn flow.end into a failure")
+}

--- a/internal/engine/outputs.go
+++ b/internal/engine/outputs.go
@@ -3,44 +3,50 @@ package engine
 import (
 	"maps"
 	"sync"
+
+	"github.com/quike/keepup/internal/result"
 )
 
-// OutputStore is a goroutine-safe key/value store of group outputs.
+// OutputStore is a goroutine-safe key/value store of structured group results.
 type OutputStore interface {
-	Get(name string) (string, bool)
-	Set(name, value string)
-	Snapshot() map[string]string
+	Get(name string) (result.RunResult, bool)
+	Set(name string, r result.RunResult)
+	Snapshot() map[string]result.RunResult
 }
 
 // MemoryOutputStore is the default in-memory implementation.
 type MemoryOutputStore struct {
 	mu   sync.RWMutex
-	data map[string]string
+	data map[string]result.RunResult
 }
 
 // NewMemoryOutputStore returns an empty store.
 func NewMemoryOutputStore() *MemoryOutputStore {
-	return &MemoryOutputStore{data: make(map[string]string)}
+	return &MemoryOutputStore{data: make(map[string]result.RunResult)}
 }
 
-func (s *MemoryOutputStore) Get(name string) (string, bool) {
+// Get returns the stored RunResult for name, if any.
+func (s *MemoryOutputStore) Get(name string) (result.RunResult, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	v, ok := s.data[name]
 	return v, ok
 }
 
-func (s *MemoryOutputStore) Set(name, value string) {
+// Set stores a RunResult under name.
+//
+//nolint:gocritic // value semantics are part of the OutputStore contract; pointer would alias caller storage
+func (s *MemoryOutputStore) Set(name string, r result.RunResult) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.data[name] = value
+	s.data[name] = r
 }
 
 // Snapshot returns a copy of the current state for safe iteration.
-func (s *MemoryOutputStore) Snapshot() map[string]string {
+func (s *MemoryOutputStore) Snapshot() map[string]result.RunResult {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make(map[string]string, len(s.data))
+	out := make(map[string]result.RunResult, len(s.data))
 	maps.Copy(out, s.data)
 	return out
 }

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -82,7 +82,7 @@ func (r *ShellRunner) Run(ctx context.Context, g *config.Group, params []string,
 		Output:     captureCombined.String(),
 		ExitCode:   exitCode,
 		DurationMs: durationMs,
-		Status:     resultStatusOK,
+		Status:     result.StatusOK,
 	}
 	if runErr != nil {
 		return rr, fmt.Errorf("run %q: %w", g.Name, runErr)

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -11,8 +11,10 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 )
 
 const (
@@ -20,9 +22,9 @@ const (
 	defaultPosixSh = "/bin/sh"
 )
 
-// Runner executes a single group and returns its captured stdout/stderr as a string.
+// Runner executes a single group and returns its structured RunResult.
 type Runner interface {
-	Run(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) (string, error)
+	Run(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) (result.RunResult, error)
 }
 
 // ShellRunner executes a group via os/exec, optionally through a system shell.
@@ -33,7 +35,7 @@ type Runner interface {
 // it through the user's preferred shell; that mode is opt-in.
 type ShellRunner struct {
 	// Stdout and Stderr are forwarded for live output; outputs are also captured
-	// into the returned string. If nil, os.Stdout/os.Stderr are used.
+	// into the returned RunResult. If nil, os.Stdout/os.Stderr are used.
 	Stdout io.Writer
 	Stderr io.Writer
 }
@@ -43,12 +45,54 @@ func NewShellRunner() *ShellRunner {
 	return &ShellRunner{Stdout: os.Stdout, Stderr: os.Stderr}
 }
 
-// Run honors ctx for cancellation. The returned string is the combined
-// stdout+stderr capture of the child process.
+// Run honors ctx for cancellation. It captures stdout, stderr, and the
+// chronologically interleaved combined stream into three buffers populated on
+// the returned RunResult; ExitCode and DurationMs are also filled in.
 //
 // The command and arguments come from user-supplied configuration; that is
 // the point of this tool. gosec G204 is suppressed for the exec call.
-func (r *ShellRunner) Run(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) (string, error) {
+func (r *ShellRunner) Run(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) (result.RunResult, error) {
+	cmd := r.buildCmd(ctx, g, params, globalEnv)
+
+	captureStdout := &safeBuf{}
+	captureStderr := &safeBuf{}
+	captureCombined := &safeBuf{}
+	stdout := r.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := r.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	cmd.Stdout = io.MultiWriter(stdout, captureStdout, captureCombined)
+	cmd.Stderr = io.MultiWriter(stderr, captureStderr, captureCombined)
+
+	start := time.Now()
+	runErr := cmd.Run()
+	durationMs := time.Since(start).Milliseconds()
+
+	exitCode := 0
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	rr := result.RunResult{
+		Stdout:     captureStdout.String(),
+		Stderr:     captureStderr.String(),
+		Output:     captureCombined.String(),
+		ExitCode:   exitCode,
+		DurationMs: durationMs,
+		Status:     resultStatusOK,
+	}
+	if runErr != nil {
+		return rr, fmt.Errorf("run %q: %w", g.Name, runErr)
+	}
+	return rr, nil
+}
+
+// buildCmd assembles the exec.Cmd for a group invocation, honoring shell
+// opt-in and the layered environment.
+func (r *ShellRunner) buildCmd(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if g.UseShell() {
 		shell := pickShell(g.Shell)
@@ -60,25 +104,8 @@ func (r *ShellRunner) Run(ctx context.Context, g *config.Group, params []string,
 	} else {
 		cmd = exec.CommandContext(ctx, g.Command, params...) //nolint:gosec // user-declared command
 	}
-
 	cmd.Env = mergeEnvs(os.Environ(), globalEnv, g.Env)
-
-	capture := &safeBuf{}
-	stdout := r.Stdout
-	if stdout == nil {
-		stdout = os.Stdout
-	}
-	stderr := r.Stderr
-	if stderr == nil {
-		stderr = os.Stderr
-	}
-	cmd.Stdout = io.MultiWriter(stdout, capture)
-	cmd.Stderr = io.MultiWriter(stderr, capture)
-
-	if err := cmd.Run(); err != nil {
-		return capture.String(), fmt.Errorf("run %q: %w", g.Name, err)
-	}
-	return capture.String(), nil
+	return cmd
 }
 
 // safeBuf is a goroutine-safe wrapper around bytes.Buffer; os/exec writes
@@ -127,18 +154,18 @@ func shellFlag() string {
 // mergeEnvs converts the base process environment plus zero or more overlay
 // maps into a flat KEY=VALUE slice suitable for *exec.Cmd.Env.
 func mergeEnvs(base []string, overrides ...map[string]string) []string {
-	result := make(map[string]string, len(base))
+	merged := make(map[string]string, len(base))
 	for _, raw := range base {
 		k, v, ok := strings.Cut(raw, "=")
 		if ok {
-			result[k] = v
+			merged[k] = v
 		}
 	}
 	for _, layer := range overrides {
-		maps.Copy(result, layer)
+		maps.Copy(merged, layer)
 	}
-	final := make([]string, 0, len(result))
-	for k, v := range result {
+	final := make([]string, 0, len(merged))
+	for k, v := range merged {
 		final = append(final, fmt.Sprintf("%s=%s", k, v))
 	}
 	return final

--- a/internal/engine/runner_test.go
+++ b/internal/engine/runner_test.go
@@ -64,7 +64,8 @@ func TestShellRunner_DirectExecNoShell(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.want, out)
+			assert.Equal(t, tc.want, out.Output)
+			assert.Equal(t, tc.want, out.Stdout)
 		})
 	}
 }
@@ -78,7 +79,7 @@ func TestShellRunner_ShellModeOptIn(t *testing.T) {
 	out, err := r.Run(context.Background(),
 		&config.Group{Name: "g", Command: "echo $((1+2))", Shell: "/bin/sh"}, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "3\n", strings.TrimLeft(out, " "))
+	assert.Equal(t, "3\n", strings.TrimLeft(out.Output, " "))
 }
 
 func TestShellRunner_ShellModeWithParams(t *testing.T) {
@@ -92,7 +93,7 @@ func TestShellRunner_ShellModeWithParams(t *testing.T) {
 		&config.Group{Name: "g", Command: "echo", Shell: "/bin/sh"},
 		[]string{"hello", "world"}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "hello world\n", out)
+	assert.Equal(t, "hello world\n", out.Output)
 }
 
 func TestShellRunner_NilWritersFallbackToProcessStdio(t *testing.T) {
@@ -105,7 +106,7 @@ func TestShellRunner_NilWritersFallbackToProcessStdio(t *testing.T) {
 	out, err := r.Run(context.Background(),
 		&config.Group{Name: "g", Command: "echo"}, []string{"x"}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "x\n", out)
+	assert.Equal(t, "x\n", out.Output)
 }
 
 func TestShellRunner_FailingCommand(t *testing.T) {
@@ -143,7 +144,7 @@ func TestShellRunner_EnvOverlayPrecedence(t *testing.T) {
 	)
 	require.NoError(t, err)
 	// group env overrides global, global overrides base
-	assert.Equal(t, "group\n", out)
+	assert.Equal(t, "group\n", out.Output)
 }
 
 func TestMergeEnvs(t *testing.T) {
@@ -185,4 +186,24 @@ func TestShellFlag(t *testing.T) {
 	t.Parallel()
 	// shellFlag returns a non-empty platform-specific switch.
 	assert.NotEmpty(t, shellFlag())
+}
+
+func TestShellRunner_SeparatesStdoutAndStderr(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	r := &ShellRunner{Stdout: io.Discard, Stderr: io.Discard}
+	g := &config.Group{
+		Name:    "probe",
+		Command: "printf 'out'; printf 'err' >&2",
+		Shell:   "/bin/sh",
+	}
+	rr, err := r.Run(context.Background(), g, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "out", rr.Stdout)
+	assert.Equal(t, "err", rr.Stderr)
+	assert.Contains(t, rr.Output, "out")
+	assert.Contains(t, rr.Output, "err")
+	assert.Equal(t, "ok", rr.Status)
+	assert.Equal(t, 0, rr.ExitCode)
+	assert.GreaterOrEqual(t, rr.DurationMs, int64(0))
 }

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -115,7 +115,7 @@ func (s *dagScheduler) drainReady() {
 			return
 		case decisionSkip:
 			s.skipped[name] = true
-			s.engine.outputs.Set(name, result.RunResult{Status: resultStatusSkipped})
+			s.engine.outputs.Set(name, result.RunResult{Status: result.StatusSkipped})
 			s.engine.emitGroupSkipped(name, s.skipReason[name])
 			s.onDone(name, true)
 		case decisionRun:

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/plan"
+	"github.com/quike/keepup/internal/result"
 )
 
 // dagScheduler holds the scheduler-goroutine-local bookkeeping for a dag run.
@@ -45,7 +46,7 @@ type dagScheduler struct {
 	launch func(name string)
 	cancel context.CancelFunc
 
-	baseline func() map[string]string // stable snapshot for when: evaluation
+	baseline func() map[string]result.RunResult // stable snapshot for when: evaluation
 }
 
 // onDone resolves a terminal node's successors. A skipped node poisons its
@@ -146,10 +147,10 @@ func (e *Engine) runDAGPlan(ctx context.Context, p *plan.Plan, flow *config.Flow
 
 	var (
 		snapMu sync.RWMutex
-		snap   = make(map[string]string, len(p.Members))
+		snap   = make(map[string]result.RunResult, len(p.Members))
 	)
 	maps.Copy(snap, e.outputs.Snapshot())
-	baseline := func() map[string]string {
+	baseline := func() map[string]result.RunResult {
 		snapMu.RLock()
 		defer snapMu.RUnlock()
 		return cloneSnapshot(snap)
@@ -227,8 +228,8 @@ func (e *Engine) emitGroupSkipped(name, reason string) {
 	e.emitter.Emit(Event{Event: EventGroupEnd, Group: name, Status: StatusSkipped, Reason: reason})
 }
 
-func cloneSnapshot(m map[string]string) map[string]string {
-	out := make(map[string]string, len(m))
+func cloneSnapshot(m map[string]result.RunResult) map[string]result.RunResult {
+	out := make(map[string]result.RunResult, len(m))
 	maps.Copy(out, m)
 	return out
 }

--- a/internal/engine/scheduler_dag.go
+++ b/internal/engine/scheduler_dag.go
@@ -115,6 +115,7 @@ func (s *dagScheduler) drainReady() {
 			return
 		case decisionSkip:
 			s.skipped[name] = true
+			s.engine.outputs.Set(name, result.RunResult{Status: resultStatusSkipped})
 			s.engine.emitGroupSkipped(name, s.skipReason[name])
 			s.onDone(name, true)
 		case decisionRun:

--- a/internal/engine/scheduler_dag_test.go
+++ b/internal/engine/scheduler_dag_test.go
@@ -125,3 +125,37 @@ func TestDAG_When_RenderErrorAbortsFlow(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 	assert.False(t, ranNames(r)["deploy"], "deploy must not run after its when: errored")
 }
+
+// TestDAG_SkippedGroupsAreStoredInOutputStore covers the structured-outputs
+// promise that (out "x").Status returns "skipped" for any skipped group.
+// Without this storage, downstream {{ (out "x").Status }} would observe an
+// empty Status (the zero value), which is reserved for never-declared groups.
+func TestDAG_SkippedGroupsAreStoredInOutputStore(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../config/test-resources/config-dag-when.yml")
+	require.NoError(t, err)
+
+	// test outputs "fail" -> deploy.when (eq output(test) "pass") false -> skip
+	// -> report cascade-skipped.
+	r := &fakeRunner{outputs: map[string]string{"build": "built", "test": "fail"}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	store := e.Outputs()
+
+	deployRR, ok := store.Get("deploy")
+	require.True(t, ok, "directly when:-skipped deploy must be stored")
+	assert.Equal(t, "skipped", deployRR.Status)
+
+	reportRR, ok := store.Get("report")
+	require.True(t, ok, "cascade-skipped report must be stored")
+	assert.Equal(t, "skipped", reportRR.Status)
+
+	// Sanity: groups that ran are stored with Status "ok".
+	buildRR, ok := store.Get("build")
+	require.True(t, ok)
+	assert.Equal(t, "ok", buildRR.Status)
+	testRR, ok := store.Get("test")
+	require.True(t, ok)
+	assert.Equal(t, "ok", testRR.Status)
+}

--- a/internal/engine/scheduler_step.go
+++ b/internal/engine/scheduler_step.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/plan"
+	"github.com/quike/keepup/internal/result"
 	"github.com/quike/keepup/internal/template"
 )
 
 // evalWhen renders a step's `when` predicate and reports whether the step
 // should run. The result is falsey (skip) for "", "false", "0", "no", "off".
-func (e *Engine) evalWhen(expr string, baseline map[string]string) (bool, error) {
+func (e *Engine) evalWhen(expr string, baseline map[string]result.RunResult) (bool, error) {
 	out, err := e.expander.Expand(expr, template.Data{Outputs: baseline, Env: e.cfg.Env})
 	if err != nil {
 		return false, err

--- a/internal/engine/scheduler_step.go
+++ b/internal/engine/scheduler_step.go
@@ -45,6 +45,9 @@ func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan, flow *config.Flo
 			}
 			if !run {
 				e.log.Info("step skipped", "step", waveIdx+1, "reason", "when", "predicate", step.When)
+				for _, name := range step.Run {
+					e.outputs.Set(name, result.RunResult{Status: resultStatusSkipped})
+				}
 				continue
 			}
 		}

--- a/internal/engine/scheduler_step.go
+++ b/internal/engine/scheduler_step.go
@@ -46,7 +46,7 @@ func (e *Engine) runStepPlan(ctx context.Context, p *plan.Plan, flow *config.Flo
 			if !run {
 				e.log.Info("step skipped", "step", waveIdx+1, "reason", "when", "predicate", step.When)
 				for _, name := range step.Run {
-					e.outputs.Set(name, result.RunResult{Status: resultStatusSkipped})
+					e.outputs.Set(name, result.RunResult{Status: result.StatusSkipped})
 				}
 				continue
 			}

--- a/internal/engine/template_integration_test.go
+++ b/internal/engine/template_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
 )
 
 // These tests exercise the real template.Expander through the engine, covering
@@ -105,7 +106,7 @@ type recordingRunner struct {
 	commands map[string]string
 }
 
-func (r *recordingRunner) Run(_ context.Context, g *config.Group, params []string, _ map[string]string) (string, error) {
+func (r *recordingRunner) Run(_ context.Context, g *config.Group, params []string, _ map[string]string) (result.RunResult, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.params == nil {
@@ -114,7 +115,8 @@ func (r *recordingRunner) Run(_ context.Context, g *config.Group, params []strin
 	}
 	r.params[g.Name] = strings.Join(params, ",")
 	r.commands[g.Name] = g.Command
-	return r.outputs[g.Name], nil
+	stdout := r.outputs[g.Name]
+	return result.RunResult{Stdout: stdout, Output: stdout, Status: "ok"}, nil
 }
 
 func TestEngine_Template_BadCommandFailsGroup(t *testing.T) {
@@ -132,10 +134,10 @@ func TestEngine_Template_BadCommandFailsGroup(t *testing.T) {
 // and echoes its first param as output so downstream refs resolve.
 type captureCommandRunner struct{ lastCommand string }
 
-func (r *captureCommandRunner) Run(_ context.Context, g *config.Group, params []string, _ map[string]string) (string, error) {
+func (r *captureCommandRunner) Run(_ context.Context, g *config.Group, params []string, _ map[string]string) (result.RunResult, error) {
 	r.lastCommand = g.Command
 	if len(params) > 0 {
-		return params[0], nil
+		return result.RunResult{Stdout: params[0], Output: params[0], Status: "ok"}, nil
 	}
-	return "", nil
+	return result.RunResult{Status: "ok"}, nil
 }

--- a/internal/engine/when_test.go
+++ b/internal/engine/when_test.go
@@ -108,3 +108,40 @@ func TestEngine_When_BadTemplateErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "when")
 }
+
+// TestStep_SkippedStepStoresEachGroupAsSkipped covers the step-mode analog:
+// a when:-skipped step now stores RunResult{Status:"skipped"} for each of its
+// groups, so (out "x").Status reads "skipped" instead of "" (which would mean
+// "never declared").
+func TestStep_SkippedStepStoresEachGroupAsSkipped(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Version: config.SchemaVersion,
+		Groups: []config.Group{
+			{Name: "a", Command: "echo"},
+			{Name: "b", Command: "echo"},
+		},
+		Flows: map[string]config.Flow{
+			"f": {Mode: config.ModeStep, Steps: []config.Step{
+				{Run: []string{"a"}, When: "false"}, // step skipped
+				{Run: []string{"b"}},                // runs normally
+			}},
+		},
+	}
+	r := &fakeRunner{outputs: map[string]string{"b": "ran"}}
+	e := New(cfg, WithRunner(r))
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+
+	store := e.Outputs()
+
+	aRR, ok := store.Get("a")
+	require.True(t, ok, "step-skipped group must be stored")
+	assert.Equal(t, "skipped", aRR.Status)
+
+	// 'a' was skipped; 'b' should be the only call.
+	assert.Equal(t, []string{"b:"}, r.calls)
+
+	bRR, ok := store.Get("b")
+	require.True(t, ok)
+	assert.Equal(t, "ok", bRR.Status)
+}

--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -1,0 +1,33 @@
+// Package result defines RunResult, the structured outcome of running a group.
+// It lives in its own leaf package so engine, cache, and template can all
+// import it without creating an import cycle (template cannot import engine).
+package result
+
+// RunResult is the structured outcome of evaluating a group. Templates access
+// it via `(out "x").Field`; the engine stores it in OutputStore; the cache
+// persists it across runs.
+//
+// The zero value is meaningful: Status == "" appears only for groups that
+// were never declared or never reached the store. Every declared, evaluated
+// group ends up with one of the four known statuses ("ok", "skipped",
+// "cached", "dry-run").
+type RunResult struct {
+	// Stdout is the captured stdout only (independent of Stderr).
+	Stdout string `json:"stdout,omitempty"`
+	// Stderr is the captured stderr only.
+	Stderr string `json:"stderr,omitempty"`
+	// Output is the chronologically interleaved merge of stdout and stderr,
+	// matching the historical (pre-structured-outputs) capture behavior.
+	// The `output "x"` template function returns strings.TrimSpace(Output).
+	Output string `json:"output,omitempty"`
+	// ExitCode is the process exit code. Always 0 in stored results today
+	// (non-zero aborts the flow before storage). Laid down for a future
+	// soft-fail / continue-on-error feature.
+	ExitCode int `json:"exitCode,omitempty"`
+	// DurationMs is wall-clock milliseconds for the command run. 0 for
+	// skipped and cache-hit groups.
+	DurationMs int64 `json:"durationMs,omitempty"`
+	// Status is one of "ok", "skipped", "cached", "dry-run". An empty Status
+	// indicates a never-stored group.
+	Status string `json:"status,omitempty"`
+}

--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -27,7 +27,22 @@ type RunResult struct {
 	// DurationMs is wall-clock milliseconds for the command run. 0 for
 	// skipped and cache-hit groups.
 	DurationMs int64 `json:"durationMs,omitempty"`
-	// Status is one of "ok", "skipped", "cached", "dry-run". An empty Status
-	// indicates a never-stored group.
+	// Status is one of the Status* constants below. An empty Status indicates
+	// a never-stored group.
 	Status string `json:"status,omitempty"`
 }
+
+// Status values a RunResult may carry. External Runner implementations set
+// StatusOK on a normal run; the engine overrides with the appropriate value
+// at storage time for cached / skipped / dry-run paths.
+//
+// Note: these are intentionally distinct from the event-layer status
+// constants in internal/engine/events.go (e.g. "cache-hit" vs "cached"). The
+// event stream is a wire format with its own compatibility guarantees; the
+// model layer here is what user templates read via `(out "x").Status`.
+const (
+	StatusOK      = "ok"
+	StatusSkipped = "skipped"
+	StatusCached  = "cached"
+	StatusDryRun  = "dry-run"
+)

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -1,0 +1,51 @@
+package result_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/result"
+)
+
+func TestRunResultJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := result.RunResult{
+		Stdout:     "hello\n",
+		Stderr:     "warning\n",
+		Output:     "hello\nwarning\n",
+		ExitCode:   0,
+		DurationMs: 42,
+		Status:     "ok",
+	}
+	b, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	var out result.RunResult
+	require.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, in, out)
+}
+
+func TestRunResultZeroValue(t *testing.T) {
+	t.Parallel()
+	var rr result.RunResult
+	assert.Equal(t, "", rr.Status)
+	assert.Equal(t, "", rr.Stdout)
+	assert.Equal(t, "", rr.Stderr)
+	assert.Equal(t, "", rr.Output)
+	assert.Equal(t, 0, rr.ExitCode)
+	assert.Equal(t, int64(0), rr.DurationMs)
+}
+
+func TestRunResultJSONFields(t *testing.T) {
+	t.Parallel()
+	rr := result.RunResult{Stdout: "s", Stderr: "e", Output: "se", ExitCode: 1, DurationMs: 7, Status: "ok"}
+	b, err := json.Marshal(rr)
+	require.NoError(t, err)
+	got := string(b)
+	for _, want := range []string{`"stdout":"s"`, `"stderr":"e"`, `"output":"se"`, `"exitCode":1`, `"durationMs":7`, `"status":"ok"`} {
+		assert.Contains(t, got, want)
+	}
+}

--- a/internal/template/refs.go
+++ b/internal/template/refs.go
@@ -10,9 +10,12 @@ import (
 	"github.com/quike/keepup/internal/result"
 )
 
-// Refs returns the group names a template references via output("X"), in
-// encounter order (duplicates preserved; callers de-duplicate as needed).
-// Both the legacy "{{ output.X }}" form and the function form are handled.
+// Refs returns the group names a template references via output("X") or out("X"),
+// in encounter order (duplicates preserved; callers de-duplicate as needed).
+// The following forms are all handled:
+//   - legacy dot form:    {{ output.X }}
+//   - function form:      {{ output "X" }} / {{ out "X" }}
+//   - dot-access form:    {{ (out "X").ExitCode }} / {{ (out "X").Status }}
 //
 // Only string-literal arguments are extractable; a dynamically-computed name
 // (e.g. output (printf "g%d" 1)) cannot be resolved statically and is ignored.
@@ -78,10 +81,17 @@ func walkCommand(c *parse.CommandNode, refs *[]string) {
 			}
 		}
 	}
-	// Recurse into parenthesized sub-pipelines, e.g. {{ if (output "x") }}.
+	// Recurse into parenthesized sub-pipelines and chain expressions,
+	// e.g. {{ if (output "x") }} or {{ (out "x").ExitCode }}.
 	for _, a := range c.Args {
-		if pipe, ok := a.(*parse.PipeNode); ok {
-			walkPipe(pipe, refs)
+		switch n := a.(type) {
+		case *parse.PipeNode:
+			walkPipe(n, refs)
+		case *parse.ChainNode:
+			// (out "x").Field — the chain base is itself a pipeline; walk into it.
+			if pipe, ok := n.Node.(*parse.PipeNode); ok {
+				walkPipe(pipe, refs)
+			}
 		}
 	}
 }

--- a/internal/template/refs.go
+++ b/internal/template/refs.go
@@ -6,6 +6,8 @@ import (
 	"text/template/parse"
 
 	"github.com/Masterminds/sprig/v3"
+
+	"github.com/quike/keepup/internal/result"
 )
 
 // Refs returns the group names a template references via output("X"), in
@@ -18,6 +20,7 @@ func Refs(s string) ([]string, error) {
 	fm := sprig.TxtFuncMap()
 	// Stub the keepup functions so parsing succeeds without real data.
 	fm["output"] = func(string) string { return "" }
+	fm["out"] = func(string) result.RunResult { return result.RunResult{} }
 	fm["env"] = func(string) string { return "" }
 
 	t, err := template.New("ref").Funcs(fm).Parse(normalize(s))
@@ -68,7 +71,8 @@ func walkPipe(p *parse.PipeNode, refs *[]string) {
 
 func walkCommand(c *parse.CommandNode, refs *[]string) {
 	if len(c.Args) >= 2 {
-		if id, ok := c.Args[0].(*parse.IdentifierNode); ok && id.Ident == "output" {
+		if id, ok := c.Args[0].(*parse.IdentifierNode); ok &&
+			(id.Ident == "output" || id.Ident == "out") {
 			if s, ok := c.Args[1].(*parse.StringNode); ok {
 				*refs = append(*refs, s.Text)
 			}

--- a/internal/template/refs_test.go
+++ b/internal/template/refs_test.go
@@ -29,6 +29,11 @@ func TestRefs(t *testing.T) {
 		{"env not counted as ref", `{{ env "HOME" }}`, nil},
 		{"mixed legacy and func", `{{ output.a }} {{ output "b" }}`, []string{"a", "b"}},
 		{"dynamic name not extractable", `{{ output (printf "g%d" 1) }}`, nil},
+		{"out func form", `{{ out "a" }}`, []string{"a"}},
+		{"out dot-access ExitCode", `{{ (out "a").ExitCode }}`, []string{"a"}},
+		{"out dot-access Status in if", `{{ if (out "a").Status }}x{{ end }}`, []string{"a"}},
+		{"out with sprig pipe", `{{ out "a" | printf "%v" }}`, []string{"a"}},
+		{"output dot-access from output also works", `{{ (output "a") }}`, []string{"a"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -22,6 +22,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+
+	"github.com/quike/keepup/internal/result"
 )
 
 // legacyRe matches the original "{{ output.NAME }}" form (optional whitespace
@@ -38,8 +40,8 @@ func normalize(s string) string {
 
 // Data is the context a template is rendered against.
 type Data struct {
-	Outputs map[string]string // group name → captured stdout
-	Env     map[string]string // merged keepup environment
+	Outputs map[string]result.RunResult // group name → structured run result
+	Env     map[string]string           // merged keepup environment
 }
 
 // Expander renders a templated string against Data. Implementations must be
@@ -76,7 +78,14 @@ func funcMap(data Data) template.FuncMap {
 	fm := sprig.TxtFuncMap()
 	// output trims surrounding whitespace, matching the original substring
 	// expander so existing configs render identically.
-	fm["output"] = func(name string) string { return strings.TrimSpace(data.Outputs[name]) }
+	fm["output"] = func(name string) string {
+		return strings.TrimSpace(data.Outputs[name].Output)
+	}
+	// out returns the full RunResult so templates can read individual fields,
+	// e.g. (out "x").ExitCode or (out "x").Status.
+	fm["out"] = func(name string) result.RunResult {
+		return data.Outputs[name]
+	}
 	fm["env"] = func(key string) string { return data.Env[key] }
 	return fm
 }

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -5,16 +5,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/result"
 )
 
 func TestExpand(t *testing.T) {
 	t.Parallel()
 	data := Data{
-		Outputs: map[string]string{
-			"build":      "bin/keepup",
-			"global-env": "GLOBAL",
-			"sha":        "abcdef1234567890",
-			"padded":     "  v\n",
+		Outputs: map[string]result.RunResult{
+			"build":      {Output: "bin/keepup"},
+			"global-env": {Output: "GLOBAL"},
+			"sha":        {Output: "abcdef1234567890"},
+			"padded":     {Output: "  v\n"},
 		},
 		Env: map[string]string{"HOME": "/home/quike", "LANG": "en_US"},
 	}
@@ -63,13 +65,13 @@ func TestExpand(t *testing.T) {
 func TestExpand_Sprig(t *testing.T) {
 	t.Parallel()
 	data := Data{
-		Outputs: map[string]string{
-			"name":   "Keep Up",
-			"sha":    "abcdef1234567890",
-			"csv":    "a,b,c",
-			"padded": "  spaced  ",
-			"empty":  "",
-			"num":    "21",
+		Outputs: map[string]result.RunResult{
+			"name":   {Output: "Keep Up"},
+			"sha":    {Output: "abcdef1234567890"},
+			"csv":    {Output: "a,b,c"},
+			"padded": {Output: "  spaced  "},
+			"empty":  {Output: ""},
+			"num":    {Output: "21"},
 		},
 		Env: map[string]string{"HOME": "/home/q"},
 	}
@@ -168,4 +170,75 @@ func TestNormalize(t *testing.T) {
 	for in, want := range tests {
 		assert.Equal(t, want, normalize(in), "input=%q", in)
 	}
+}
+
+// TestOutputBackCompat pins the contract that `output "x"` still returns
+// strings.TrimSpace(Outputs[x].Output) and works in sprig pipes — every
+// existing template must keep rendering identically.
+func TestOutputBackCompat(t *testing.T) {
+	t.Parallel()
+	exp := NewExpander()
+	data := Data{
+		Outputs: map[string]result.RunResult{
+			"x": {Output: "  hello world  \n", Stdout: "hello world\n", Status: "ok"},
+		},
+	}
+
+	got, err := exp.Expand(`{{ output "x" }}`, data)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", got)
+
+	// Sprig string pipe still works because output returns a string.
+	got, err = exp.Expand(`{{ output "x" | upper }}`, data)
+	require.NoError(t, err)
+	assert.Equal(t, "HELLO WORLD", got)
+}
+
+// TestOutNewFunction asserts that `out "x"` returns the full RunResult and
+// every field is reachable via dot access.
+func TestOutNewFunction(t *testing.T) {
+	t.Parallel()
+	exp := NewExpander()
+	data := Data{
+		Outputs: map[string]result.RunResult{
+			"test": {
+				Stdout:     "pass",
+				Stderr:     "warning\n",
+				Output:     "passwarning\n",
+				ExitCode:   0,
+				DurationMs: 73,
+				Status:     "ok",
+			},
+		},
+	}
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{`{{ (out "test").Stdout }}`, "pass"},
+		{`{{ (out "test").Stderr }}`, "warning\n"},
+		{`{{ (out "test").Output }}`, "passwarning\n"},
+		{`{{ (out "test").ExitCode }}`, "0"},
+		{`{{ (out "test").DurationMs }}`, "73"},
+		{`{{ (out "test").Status }}`, "ok"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			t.Parallel()
+			got, err := exp.Expand(tc.expr, data)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestOutForMissingGroup confirms the zero RunResult is returned for a name
+// the engine never stored — Status is the empty string in that case.
+func TestOutForMissingGroup(t *testing.T) {
+	t.Parallel()
+	exp := NewExpander()
+	data := Data{Outputs: map[string]result.RunResult{}}
+	got, err := exp.Expand(`{{ (out "nope").Status }}`, data)
+	require.NoError(t, err)
+	assert.Equal(t, "", got, "missing group should yield zero RunResult, empty Status")
 }


### PR DESCRIPTION
Closes #22.

## What

Adds a sibling template function `out "x"` that returns a structured `RunResult` value carrying separated stdout/stderr, merged output, exit code, duration, and run status. The existing `output "x"` function is unchanged — every existing template continues to work byte-for-byte identically.

```yaml
when: '{{ eq (out "test").Status "ok" }}'
when: '{{ gt (out "probe").DurationMs 500 }}'
when: '{{ contains "WARNING" (out "lint").Stderr }}'
```

`RunResult` fields: `Stdout`, `Stderr`, `Output` (merged), `ExitCode`, `DurationMs`, `Status` (one of `"ok"` / `"skipped"` / `"cached"` / `"dry-run"`).

## How

- New leaf package `internal/result/` owns `RunResult` (avoids a latent `template → engine` import cycle).
- `Runner.Run`, `OutputStore.{Get,Set,Snapshot}`, `cache.Entry`, and `template.Data.Outputs` all widen to use `RunResult`.
- `ShellRunner` captures stdout / stderr / combined into three buffers via `io.MultiWriter`.
- Engine sets `Status` per code path: `"ok"` (or `"dry-run"`) on success, `"cached"` on cache hit, `"skipped"` on skip-if, `when:`-skip (dag + step), and cascade-skip.
- `output` template function unchanged (returns trimmed `.Output`); new `out` function returns the whole `RunResult`. Refs walker recognises both forms, including `(out "x").Field` dot-access via `ChainNode`.
- Cache fingerprint salt bumped to `v2` — one cold rebuild after upgrade; steady-state hits return on the next run.

## Behaviour changes worth flagging

- **Skipped groups now leave a trace.** `when:`-skipped (dag + step), cascade-skipped, and `skip-if:`-skipped groups are stored with `Status:"skipped"` and empty `Output`. Previously they left no entry in `OutputStore`.
- **`skip-if:` no longer exposes a stale cached `Output`.** Templates that read a skipped producer's output via `{{ output "x" }}` now see `""`. Use `(out "x").Status == "skipped"` to branch on skip explicitly.
- **Cache cold-rebuild on upgrade.** First run after upgrading rebuilds every cached step due to the fingerprint salt bump.

## Backward compatibility

- `output "x"` returns a byte-identical trimmed merged string — every existing template, fixture, and doc example works unchanged.
- Sprig pipes on `output` still work (`{{ output "x" | upper }}` etc.).
- External `Runner` implementations (if any exist outside this repo) need to update the return type.

## Tests / verification

Table-driven tests across `result`, `cache`, `engine`, `template`, `config` (incl. a shared `config-out-struct.yml` fixture loaded by both config and engine tests exercising every Status path), `go test -race ./...` and `golangci-lint run ./...` clean. Real-binary verified for skip-cascade, all-run, and dry-run paths.

Docs updated: README features table, `docs/CONFIG.md`, `docs/FAQ.md`, `docs/USAGE.md`.

## Out of scope (deferred follow-ups)

- Soft-fail / `continue-on-error:` — separate issue. `.ExitCode` is laid down but effectively 0-only until that ships.
- Per-attempt history (`(out "x").Attempts[i]`).
- stdout/stderr capture limits / truncation.
