### PR TITLE
feat: --events stream for keepup watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ config-*.yml
 !**/**/test-resources/config-**.yml
 *.pem
 .claude/
+
+# keepup fingerprint cache (runtime artifact)
+.keepup-cache/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ shell unless you ask for it), and incremental re-runs via content-based caching.
 | **Safe execution**       | Commands run as real argv by default (no shell injection); opt into a shell per group with `shell:`.                        |
 | **Env layering**         | Global `env:` plus per-group overrides, merged over the process environment.                                                |
 | **Discoverability**      | `keepup list`, `keepup validate`, and `keepup graph` (Mermaid diagram of the data DAG).                                     |
-| **JSON events**          | `keepup run --events` emits a newline-delimited JSON stream (`group.end` with status + durationMs) for CI tooling.          |
+| **JSON events**          | `keepup run --events` and `keepup watch --events` emit a newline-delimited JSON stream for CI tooling. `watch` adds a `watch.trigger {"files":[...]}` event before each debounced re-run; the banner writes to stderr so `--events -` yields pure JSON on stdout. |
 | **Migration**            | `keepup migrate` converts legacy v1 configs to v2 and validates the result.                                                 |
 
 ## Quick start

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -54,27 +54,31 @@ func resolveWatchFlow(cmd *cobra.Command, args []string, opts *runtimeOpts) (str
 type watchSourceSetup struct {
 	src      watch.Source
 	dirCount int
-	close    func()
+	cleanup  func()
 }
 
 // setupWatchSource builds the fsnotify source and registers all resolved dirs.
 func setupWatchSource(patterns []string) (watchSourceSetup, error) {
+	setup := watchSourceSetup{cleanup: func() {}}
 	src, err := watch.NewFSNotifySource()
 	if err != nil {
-		return watchSourceSetup{}, fmt.Errorf("create file watcher: %w", err)
+		return setup, fmt.Errorf("create file watcher: %w", err)
 	}
 	dirs, err := watch.ResolveWatchDirs(patterns)
 	if err != nil {
 		_ = src.Close()
-		return watchSourceSetup{}, fmt.Errorf("resolve watch dirs: %w", err)
+		return setup, fmt.Errorf("resolve watch dirs: %w", err)
 	}
 	for _, d := range dirs {
 		if err := src.Add(d); err != nil {
 			_ = src.Close()
-			return watchSourceSetup{}, fmt.Errorf("watch %q: %w", d, err)
+			return setup, fmt.Errorf("watch %q: %w", d, err)
 		}
 	}
-	return watchSourceSetup{src: src, dirCount: len(dirs), close: func() { _ = src.Close() }}, nil
+	setup.src = src
+	setup.dirCount = len(dirs)
+	setup.cleanup = func() { _ = src.Close() }
+	return setup, nil
 }
 
 // runWatch is the body of the watch command, factored out of RunE so the
@@ -97,7 +101,7 @@ func runWatch(cmd *cobra.Command, args []string, opts *runtimeOpts, eventsPath s
 	if err != nil {
 		return err
 	}
-	defer setup.close()
+	defer setup.cleanup()
 
 	// Banner goes to stderr so `--events -` can claim stdout for pure JSON.
 	fmt.Fprintf(cmd.ErrOrStderr(),
@@ -115,7 +119,17 @@ func runWatch(cmd *cobra.Command, args []string, opts *runtimeOpts, eventsPath s
 	}
 
 	w := watch.New(patterns, setup.src, watch.WithLogger(opts.log))
-	return w.Run(cmd.Context(), func(ctx context.Context, files []string) error {
+	return w.Run(cmd.Context(), buildOnChange(emitter, opts, flowName))
+}
+
+// buildOnChange returns the per-tick callback the watcher invokes on each
+// debounced batch. When an emitter is configured and the batch was triggered
+// by file changes (len(files) > 0), it emits a watch.trigger event before the
+// flow runs; the initial startup tick passes nil files and emits no trigger.
+// Each tick runs the flow on a fresh engine sharing the one emitter so the
+// event stream is a continuous sequence of per-tick flow envelopes.
+func buildOnChange(emitter engine.Emitter, opts *runtimeOpts, flowName string) func(context.Context, []string) error {
+	return func(ctx context.Context, files []string) error {
 		if emitter != nil && len(files) > 0 {
 			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Files: files})
 		}
@@ -128,7 +142,7 @@ func runWatch(cmd *cobra.Command, args []string, opts *runtimeOpts, eventsPath s
 		}
 		e := engine.New(opts.cfg, engineOpts...)
 		return e.RunFlow(ctx, flowName)
-	})
+	}
 }
 
 // watchPatterns collects the de-duplicated cache.reads globs across every group

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -12,8 +12,9 @@ import (
 	"github.com/quike/keepup/internal/watch"
 )
 
-func newWatchCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
+func newWatchCmd(opts *runtimeOpts, _ io.Writer) *cobra.Command {
+	var eventsPath string
+	cmd := &cobra.Command{
 		Use:   "watch [flow]",
 		Short: "Re-run a flow whenever its groups' cache.reads inputs change",
 		Long: "Watch the files declared in the cache.reads of the flow's groups and " +
@@ -21,57 +22,113 @@ func newWatchCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {
 			"so only the work that actually depends on a changed file re-executes.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.load(cmd.OutOrStdout()); err != nil {
-				return err
-			}
-			flowName := opts.cfg.Default
-			if len(args) == 1 {
-				flowName = args[0]
-			}
-			if flowName == "" {
-				return fmt.Errorf("no flow specified and no default declared")
-			}
-			flow, ok := opts.cfg.Flows[flowName]
-			if !ok {
-				return fmt.Errorf("flow %q not found", flowName)
-			}
-
-			patterns := watchPatterns(opts.cfg, &flow)
-			if len(patterns) == 0 {
-				return fmt.Errorf(
-					"flow %q has no watchable inputs: add a cache.reads block to at least one of its groups",
-					flowName,
-				)
-			}
-
-			src, err := watch.NewFSNotifySource()
-			if err != nil {
-				return fmt.Errorf("create file watcher: %w", err)
-			}
-			defer func() { _ = src.Close() }()
-
-			dirs, err := watch.ResolveWatchDirs(patterns)
-			if err != nil {
-				return fmt.Errorf("resolve watch dirs: %w", err)
-			}
-			for _, d := range dirs {
-				if err := src.Add(d); err != nil {
-					return fmt.Errorf("watch %q: %w", d, err)
-				}
-			}
-
-			fmt.Fprintf(stdout, "watching %d dir(s) for flow %q; press Ctrl-C to stop\n", len(dirs), flowName)
-
-			w := watch.New(patterns, src, watch.WithLogger(opts.log))
-			return w.Run(cmd.Context(), func(ctx context.Context, _ []string) error {
-				e := engine.New(opts.cfg,
-					engine.WithLogger(opts.log),
-					engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),
-				)
-				return e.RunFlow(ctx, flowName)
-			})
+			return runWatch(cmd, args, opts, eventsPath)
 		},
 	}
+	cmd.Flags().StringVar(&eventsPath, "events", "",
+		"Write a JSON event stream to this file ('-' for stdout)")
+	return cmd
+}
+
+// resolveWatchFlow loads the config and returns the resolved flow name + flow.
+func resolveWatchFlow(cmd *cobra.Command, args []string, opts *runtimeOpts) (string, config.Flow, error) {
+	if err := opts.load(cmd.OutOrStdout()); err != nil {
+		return "", config.Flow{}, err
+	}
+	flowName := opts.cfg.Default
+	if len(args) == 1 {
+		flowName = args[0]
+	}
+	if flowName == "" {
+		return "", config.Flow{}, fmt.Errorf("no flow specified and no default declared")
+	}
+	flow, ok := opts.cfg.Flows[flowName]
+	if !ok {
+		return "", config.Flow{}, fmt.Errorf("flow %q not found", flowName)
+	}
+	return flowName, flow, nil
+}
+
+// watchSourceSetup bundles the fsnotify source, the dir count, and a cleanup
+// closure so setupWatchSource has a self-documenting return type.
+type watchSourceSetup struct {
+	src      watch.Source
+	dirCount int
+	close    func()
+}
+
+// setupWatchSource builds the fsnotify source and registers all resolved dirs.
+func setupWatchSource(patterns []string) (watchSourceSetup, error) {
+	src, err := watch.NewFSNotifySource()
+	if err != nil {
+		return watchSourceSetup{}, fmt.Errorf("create file watcher: %w", err)
+	}
+	dirs, err := watch.ResolveWatchDirs(patterns)
+	if err != nil {
+		_ = src.Close()
+		return watchSourceSetup{}, fmt.Errorf("resolve watch dirs: %w", err)
+	}
+	for _, d := range dirs {
+		if err := src.Add(d); err != nil {
+			_ = src.Close()
+			return watchSourceSetup{}, fmt.Errorf("watch %q: %w", d, err)
+		}
+	}
+	return watchSourceSetup{src: src, dirCount: len(dirs), close: func() { _ = src.Close() }}, nil
+}
+
+// runWatch is the body of the watch command, factored out of RunE so the
+// cyclomatic complexity stays inside the project's gocyclo budget.
+func runWatch(cmd *cobra.Command, args []string, opts *runtimeOpts, eventsPath string) error {
+	flowName, flow, err := resolveWatchFlow(cmd, args, opts)
+	if err != nil {
+		return err
+	}
+
+	patterns := watchPatterns(opts.cfg, &flow)
+	if len(patterns) == 0 {
+		return fmt.Errorf(
+			"flow %q has no watchable inputs: add a cache.reads block to at least one of its groups",
+			flowName,
+		)
+	}
+
+	setup, err := setupWatchSource(patterns)
+	if err != nil {
+		return err
+	}
+	defer setup.close()
+
+	// Banner goes to stderr so `--events -` can claim stdout for pure JSON.
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"watching %d dir(s) for flow %q; press Ctrl-C to stop\n",
+		setup.dirCount, flowName)
+
+	var emitter engine.Emitter
+	if eventsPath != "" {
+		ew, closeFn, oerr := openEventsWriter(eventsPath, cmd.OutOrStdout())
+		if oerr != nil {
+			return oerr
+		}
+		defer closeFn()
+		emitter = engine.NewJSONEmitter(ew)
+	}
+
+	w := watch.New(patterns, setup.src, watch.WithLogger(opts.log))
+	return w.Run(cmd.Context(), func(ctx context.Context, files []string) error {
+		if emitter != nil && len(files) > 0 {
+			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Files: files})
+		}
+		engineOpts := []engine.Option{
+			engine.WithLogger(opts.log),
+			engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),
+		}
+		if emitter != nil {
+			engineOpts = append(engineOpts, engine.WithEmitter(emitter))
+		}
+		e := engine.New(opts.cfg, engineOpts...)
+		return e.RunFlow(ctx, flowName)
+	})
 }
 
 // watchPatterns collects the de-duplicated cache.reads globs across every group

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -131,7 +131,7 @@ func runWatch(cmd *cobra.Command, args []string, opts *runtimeOpts, eventsPath s
 func buildOnChange(emitter engine.Emitter, opts *runtimeOpts, flowName string) func(context.Context, []string) error {
 	return func(ctx context.Context, files []string) error {
 		if emitter != nil && len(files) > 0 {
-			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Files: files})
+			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Flow: flowName, Files: files})
 		}
 		engineOpts := []engine.Option{
 			engine.WithLogger(opts.log),

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -63,7 +63,7 @@ func newWatchCmd(opts *runtimeOpts, stdout io.Writer) *cobra.Command {
 			fmt.Fprintf(stdout, "watching %d dir(s) for flow %q; press Ctrl-C to stop\n", len(dirs), flowName)
 
 			w := watch.New(patterns, src, watch.WithLogger(opts.log))
-			return w.Run(cmd.Context(), func(ctx context.Context) error {
+			return w.Run(cmd.Context(), func(ctx context.Context, _ []string) error {
 				e := engine.New(opts.cfg,
 					engine.WithLogger(opts.log),
 					engine.WithDryRun(opts.dryRun || opts.cfg.Settings.DryRun),

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/quike/keepup/internal/config"
 	"github.com/quike/keepup/internal/engine"
+	"github.com/quike/keepup/internal/logger"
 	"github.com/quike/keepup/internal/watch"
 )
 
@@ -197,14 +198,10 @@ func TestWatchCmd_EventsWiring(t *testing.T) {
 	sw := &syncBuf{}
 	emitter := engine.NewJSONEmitter(sw)
 
-	// onChange mirrors the production closure shape from cmd/watch.go.
-	onChange := func(ctx context.Context, files []string) error {
-		if len(files) > 0 {
-			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Files: files})
-		}
-		e := engine.New(cfg, engine.WithEmitter(emitter))
-		return e.RunFlow(ctx, "dev")
-	}
+	// Build the engine opts the same way the command does, then exercise the
+	// REAL production closure (not a copy) so a wiring regression is caught.
+	opts := &runtimeOpts{cfg: cfg, log: logger.Nop()}
+	onChange := buildOnChange(emitter, opts, "dev")
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -106,7 +106,7 @@ func TestWatch_FixtureDrivesRerun(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
-		_ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil })
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
 	}()
 
 	// A change to a Go file matches "**/*.go" → should trigger one re-run.

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/engine"
 	"github.com/quike/keepup/internal/watch"
 )
 
@@ -62,6 +64,26 @@ flows:
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no watchable inputs")
+}
+
+// syncBuf is a goroutine-safe bytes.Buffer wrapper used by event-stream tests
+// so the writer-goroutine and the assertion-goroutine can share state without
+// tripping the race detector.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
 }
 
 // stubSource is a minimal watch.Source driven by the test.
@@ -118,6 +140,90 @@ func TestWatch_FixtureDrivesRerun(t *testing.T) {
 	src.events <- watch.Event{Path: "README.md"}
 	time.Sleep(40 * time.Millisecond)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&runs))
+}
+
+// TestWatchCmd_BannerGoesToStderr regression-pins that the
+// "watching N dir(s)..." banner now writes to stderr, so `--events -`
+// can claim stdout for pure JSON.
+func TestWatchCmd_BannerGoesToStderr(t *testing.T) {
+	t.Parallel()
+	cfg := `
+version: 2
+groups:
+  - name: a
+    command: echo
+    cache:
+      reads: ["*.txt"]
+flows:
+  f:
+    mode: step
+    steps:
+      - run: [a]
+`
+	cfgPath := writeTempConfig(t, cfg)
+	var stdout, stderr bytes.Buffer
+	rootCmd := newRootCmd(&stdout, &stderr)
+	rootCmd.SetArgs([]string{"watch", "f", "--config", cfgPath})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately so watch returns without iterating
+	rootCmd.SetContext(ctx)
+	_ = rootCmd.Execute()
+
+	assert.Contains(t, stderr.String(), "watching",
+		"banner must go to stderr so --events - can claim stdout")
+	assert.NotContains(t, stdout.String(), "watching",
+		"stdout must not carry the banner")
+}
+
+// TestWatchCmd_EventsWiring drives the wired-up onChange callback directly
+// (the same closure cmd/watch.go installs into Watcher.Run) and asserts the
+// JSON event stream contains a watch.trigger followed by flow.start /
+// flow.end. Uses stubSource to avoid real filesystem events. This test
+// exists separately from the end-to-end cobra path so a regression in either
+// the wiring shape OR the cobra flag plumbing surfaces clearly.
+func TestWatchCmd_EventsWiring(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../internal/config/test-resources/config-watch.yml")
+	require.NoError(t, err)
+	flow := cfg.Flows["dev"]
+	patterns := watchPatterns(cfg, &flow)
+
+	src := newStubSource()
+	w := watch.New(patterns, src,
+		watch.WithDebounce(10*time.Millisecond),
+		watch.WithInitialRun(false))
+
+	sw := &syncBuf{}
+	emitter := engine.NewJSONEmitter(sw)
+
+	// onChange mirrors the production closure shape from cmd/watch.go.
+	onChange := func(ctx context.Context, files []string) error {
+		if len(files) > 0 {
+			emitter.Emit(engine.Event{Event: engine.EventWatchTrigger, Files: files})
+		}
+		e := engine.New(cfg, engine.WithEmitter(emitter))
+		return e.RunFlow(ctx, "dev")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, onChange) }()
+
+	src.events <- watch.Event{Path: "main.go"}
+	require.Eventually(t, func() bool {
+		return strings.Contains(sw.String(), `"event":"flow.end"`)
+	}, 2*time.Second, 10*time.Millisecond)
+
+	got := sw.String()
+	triggerIdx := strings.Index(got, `"event":"watch.trigger"`)
+	flowStartIdx := strings.Index(got, `"event":"flow.start"`)
+	require.NotEqual(t, -1, triggerIdx, "watch.trigger must be emitted")
+	require.NotEqual(t, -1, flowStartIdx, "flow.start must be emitted")
+	assert.Less(t, triggerIdx, flowStartIdx,
+		"watch.trigger must precede flow.start within the same tick")
+	assert.Contains(t, got, `"files":["main.go"]`)
+	assert.Contains(t, got, `"event":"flow.end"`)
 }
 
 func TestWatchCmd_ErrorsOnUnknownFlow(t *testing.T) {

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -223,6 +223,66 @@ func TestWatchCmd_EventsWiring(t *testing.T) {
 	assert.Contains(t, got, `"event":"flow.end"`)
 }
 
+// TestWatchCmd_InitialRunThenTrigger composes the REAL buildOnChange closure
+// with a watcher whose initial run is enabled, asserting the full ordered
+// contract end-to-end: the startup tick emits a flow envelope with NO
+// preceding watch.trigger, and a subsequent file change emits a watch.trigger
+// that (a) carries the flow name and (b) precedes the re-run's flow.start.
+// This guards the composition (runWatch wires buildOnChange into watch.Run)
+// that the per-piece tests do not cover together.
+func TestWatchCmd_InitialRunThenTrigger(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.LoadConfig("../internal/config/test-resources/config-watch.yml")
+	require.NoError(t, err)
+	flow := cfg.Flows["dev"]
+	patterns := watchPatterns(cfg, &flow)
+
+	src := newStubSource()
+	w := watch.New(patterns, src,
+		watch.WithDebounce(10*time.Millisecond),
+		watch.WithInitialRun(true)) // exercise the startup tick
+
+	sw := &syncBuf{}
+	emitter := engine.NewJSONEmitter(sw)
+	opts := &runtimeOpts{cfg: cfg, log: logger.Nop()}
+	onChange := buildOnChange(emitter, opts, "dev")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx, onChange) }()
+
+	// The initial run fires immediately with nil files: a flow envelope with
+	// NO watch.trigger before it.
+	require.Eventually(t, func() bool {
+		return strings.Contains(sw.String(), `"event":"flow.end"`)
+	}, 2*time.Second, 10*time.Millisecond)
+	initial := sw.String()
+	assert.NotContains(t, initial, `"event":"watch.trigger"`,
+		"the startup run must not emit a watch.trigger")
+	assert.Contains(t, initial, `"event":"flow.start"`)
+
+	// A real file change emits a watch.trigger carrying the flow, then re-runs.
+	// Wait for the re-run to FULLY complete (the second flow.end) before
+	// sampling, so the trigger and the whole re-run envelope are all present —
+	// otherwise we'd race the re-run's flow.start, which is emitted just after
+	// the trigger.
+	src.events <- watch.Event{Path: "main.go"}
+	require.Eventually(t, func() bool {
+		return strings.Count(sw.String(), `"event":"flow.end"`) >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+	full := sw.String()
+
+	// #1: the trigger self-identifies its flow (consistent with flow.*/group.* events).
+	assert.Contains(t, full, `"event":"watch.trigger","flow":"dev","files":["main.go"]`,
+		"watch.trigger must carry the flow name and changed files")
+
+	// The trigger must be followed by the re-run's flow.start.
+	triggerIdx := strings.Index(full, `"event":"watch.trigger"`)
+	require.NotEqual(t, -1, triggerIdx)
+	assert.NotEqual(t, -1, strings.Index(full[triggerIdx:], `"event":"flow.start"`),
+		"a flow.start must follow the watch.trigger")
+}
+
 func TestWatchCmd_ErrorsOnUnknownFlow(t *testing.T) {
 	t.Parallel()
 	cfg := `

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -439,6 +439,16 @@ New directories under a watched tree are added automatically as they appear, so
 files created in them are seen. Brand-new top-level trees that didn't exist when
 watch started are the one gap — restart watch if you add a whole new source root.
 
+### Does `keepup watch` emit the same event stream as `keepup run`?
+
+Yes. `keepup watch --events <path|->` emits the same `flow.start` / `group.start` / `group.end` / `flow.end` events as `run`, one envelope per re-run, plus a `watch.trigger` event before each re-run carrying the deduplicated, sorted list of file paths that triggered the debounced batch:
+
+```
+{"event":"watch.trigger","files":["src/main.go","src/util.go"]}
+```
+
+The initial run on startup emits no `watch.trigger` — the leading `flow.start` marks it. The `"watching N dir(s)…"` banner writes to stderr, so `--events -` yields pure JSON on stdout.
+
 ---
 
 ## CLI

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -441,10 +441,10 @@ watch started are the one gap — restart watch if you add a whole new source ro
 
 ### Does `keepup watch` emit the same event stream as `keepup run`?
 
-Yes. `keepup watch --events <path|->` emits the same `flow.start` / `group.start` / `group.end` / `flow.end` events as `run`, one envelope per re-run, plus a `watch.trigger` event before each re-run carrying the deduplicated, sorted list of file paths that triggered the debounced batch:
+Yes. `keepup watch --events <path|->` emits the same `flow.start` / `group.start` / `group.end` / `flow.end` events as `run`, one envelope per re-run, plus a `watch.trigger` event before each re-run carrying the flow name and the deduplicated, sorted list of file paths that triggered the debounced batch:
 
 ```
-{"event":"watch.trigger","files":["src/main.go","src/util.go"]}
+{"event":"watch.trigger","flow":"ci","files":["src/main.go","src/util.go"]}
 ```
 
 The initial run on startup emits no `watch.trigger` — the leading `flow.start` marks it. The `"watching N dir(s)…"` banner writes to stderr, so `--events -` yields pure JSON on stdout.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -96,6 +96,28 @@ keepup watch dev   # build now, then rebuild on every .go change; Ctrl-C to stop
 The flow needs at least one group with a `cache.reads` block — that's the
 watch set.
 
+### Watching a flow with the event stream
+
+`keepup watch` accepts the same `--events <path|->` flag as `keepup run`:
+
+```bash
+keepup watch ci --events -
+```
+
+The "watching N dir(s)…" banner writes to **stderr**, so stdout carries pure JSON. Each re-run emits a full `flow.start` / `group.*` / `flow.end` envelope, and every debounced batch of file changes emits a `watch.trigger` event listing the changed files:
+
+```
+{"event":"flow.start","flow":"ci","mode":"step"}
+{"event":"group.end","group":"build","status":"ok","durationMs":1}
+{"event":"flow.end","flow":"ci","status":"ok","durationMs":1}
+{"event":"watch.trigger","files":["x.txt"]}
+{"event":"flow.start","flow":"ci","mode":"step"}
+{"event":"group.end","group":"build","status":"ok","durationMs":4}
+{"event":"flow.end","flow":"ci","status":"ok","durationMs":4}
+```
+
+The first envelope is the initial run on startup — it has no preceding `watch.trigger`. Pass `--events <file>` to write the stream to a file instead of stdout.
+
 ## Multiple flows over the same groups
 
 The same groups can power many flows — that's the point of the split.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -110,7 +110,7 @@ The "watching N dir(s)…" banner writes to **stderr**, so stdout carries pure J
 {"event":"flow.start","flow":"ci","mode":"step"}
 {"event":"group.end","group":"build","status":"ok","durationMs":1}
 {"event":"flow.end","flow":"ci","status":"ok","durationMs":1}
-{"event":"watch.trigger","files":["x.txt"]}
+{"event":"watch.trigger","flow":"ci","files":["x.txt"]}
 {"event":"flow.start","flow":"ci","mode":"step"}
 {"event":"group.end","group":"build","status":"ok","durationMs":4}
 {"event":"flow.end","flow":"ci","status":"ok","durationMs":4}

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -9,10 +9,11 @@ import (
 
 // Event names emitted over the run lifecycle.
 const (
-	EventFlowStart  = "flow.start"
-	EventFlowEnd    = "flow.end"
-	EventGroupStart = "group.start"
-	EventGroupEnd   = "group.end"
+	EventFlowStart    = "flow.start"
+	EventFlowEnd      = "flow.end"
+	EventGroupStart   = "group.start"
+	EventGroupEnd     = "group.end"
+	EventWatchTrigger = "watch.trigger"
 )
 
 // Group end statuses.
@@ -34,6 +35,7 @@ type Event struct {
 	DurationMS int64     `json:"durationMs,omitempty"`
 	Err        string    `json:"err,omitempty"`
 	Reason     string    `json:"reason,omitempty"`
+	Files      []string  `json:"files,omitempty"`
 	Time       time.Time `json:"time"`
 }
 

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -137,3 +137,38 @@ func TestJSONEmitter_DAGSkippedReason(t *testing.T) {
 	assert.Equal(t, EventFlowEnd, flowEnd.Event, "flow.end event must be emitted")
 	assert.Equal(t, StatusOK, flowEnd.Status, "skip cascade must not turn flow.end into a failure")
 }
+
+// TestEvent_WatchTriggerJSONRoundTrip pins the wire format for the new
+// watch.trigger event: the Files field must survive a JSON round-trip and
+// preserve order (we emit files sorted at the watch layer).
+func TestEvent_WatchTriggerJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := Event{
+		Event: EventWatchTrigger,
+		Files: []string{"a.go", "b.go", "c.go"},
+	}
+	b, err := json.Marshal(&in)
+	require.NoError(t, err)
+
+	var out Event
+	require.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, in.Event, out.Event)
+	assert.Equal(t, in.Files, out.Files)
+
+	// Wire-format assertion: the JSON contains a non-empty files array.
+	got := string(b)
+	assert.Contains(t, got, `"event":"watch.trigger"`)
+	assert.Contains(t, got, `"files":["a.go","b.go","c.go"]`)
+}
+
+// TestEvent_FilesOmitEmpty asserts non-watch events do not include a "files"
+// key in their JSON — preserving byte-identical output for all existing
+// consumers of the event stream.
+func TestEvent_FilesOmitEmpty(t *testing.T) {
+	t.Parallel()
+	in := Event{Event: EventFlowStart, Flow: "ci"}
+	b, err := json.Marshal(&in)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"files"`,
+		"flow.start (and every other non-watch event) must omit files from JSON")
+}

--- a/internal/watch/fsnotify_source_test.go
+++ b/internal/watch/fsnotify_source_test.go
@@ -30,7 +30,9 @@ func TestFSNotifySource_RealFileChange(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
 
 	// Give the watcher a moment to settle, then modify the file.
 	time.Sleep(50 * time.Millisecond)

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"context"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/quike/keepup/internal/logger"
@@ -62,15 +63,19 @@ func New(patterns []string, src Source, opts ...Option) *Watcher {
 }
 
 // Run blocks, invoking onChange on each debounced batch of matching changes,
-// until ctx is canceled. A failing onChange is logged but does not stop the
-// watch — the whole point is to keep iterating. New directories that appear
-// under watched trees are added automatically.
-func (w *Watcher) Run(ctx context.Context, onChange func(context.Context) error) error {
+// until ctx is canceled. The slice passed to onChange contains the
+// deduplicated, sorted list of matched paths accumulated during the just-closed
+// debounce window. The initial run, when enabled, passes a nil slice — it was
+// not triggered by any file. A failing onChange is logged but does not stop
+// the watch — the whole point is to keep iterating. New directories that
+// appear under watched trees are added automatically.
+func (w *Watcher) Run(ctx context.Context, onChange func(context.Context, []string) error) error {
 	if w.initialRun {
-		w.invoke(ctx, onChange)
+		w.invoke(ctx, onChange, nil)
 	}
 
 	var debounceC <-chan time.Time
+	pending := make(map[string]struct{})
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,12 +88,19 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context) error)
 			}
 			if Matches(w.patterns, ev.Path) {
 				w.log.Debug("change detected", "path", ev.Path)
+				pending[ev.Path] = struct{}{}
 				debounceC = time.After(w.debounce)
 			}
 
 		case <-debounceC:
 			debounceC = nil
-			w.invoke(ctx, onChange)
+			files := make([]string, 0, len(pending))
+			for p := range pending {
+				files = append(files, p)
+				delete(pending, p)
+			}
+			sort.Strings(files)
+			w.invoke(ctx, onChange, files)
 
 		case err := <-w.src.Errors():
 			if err != nil {
@@ -98,8 +110,8 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context) error)
 	}
 }
 
-func (w *Watcher) invoke(ctx context.Context, onChange func(context.Context) error) {
-	if err := onChange(ctx); err != nil {
+func (w *Watcher) invoke(ctx context.Context, onChange func(context.Context, []string) error, files []string) {
+	if err := onChange(ctx, files); err != nil {
 		w.log.Error("run failed; continuing to watch", "err", err.Error())
 	}
 }

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -74,7 +74,16 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context, []stri
 		w.invoke(ctx, onChange, nil)
 	}
 
-	var debounceC <-chan time.Time
+	// debounce is a single reusable timer, armed via Reset on each matching
+	// change and consumed when the quiet window elapses. Reusing one timer
+	// (rather than time.After per event) avoids allocating a timer per
+	// filesystem event during large bursts such as a branch switch. Go 1.23+
+	// timer semantics make Stop/Reset race-free with the channel receive, so
+	// no manual drain is needed.
+	debounce := time.NewTimer(w.debounce)
+	debounce.Stop()
+	defer debounce.Stop()
+
 	pending := make(map[string]struct{})
 	for {
 		select {
@@ -89,11 +98,10 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context, []stri
 			if Matches(w.patterns, ev.Path) {
 				w.log.Debug("change detected", "path", ev.Path)
 				pending[ev.Path] = struct{}{}
-				debounceC = time.After(w.debounce)
+				debounce.Reset(w.debounce)
 			}
 
-		case <-debounceC:
-			debounceC = nil
+		case <-debounce.C:
 			files := make([]string, 0, len(pending))
 			for p := range pending {
 				files = append(files, p)

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -43,7 +43,7 @@ func TestWatcher_InitialRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
 	go func() {
-		_ = w.Run(ctx, func(context.Context) error {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error {
 			atomic.AddInt32(&runs, 1)
 			return nil
 		})
@@ -64,7 +64,9 @@ func TestWatcher_RerunsOnMatchingChange(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
 
 	src.events <- Event{Path: "main.go"}
 	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
@@ -78,7 +80,9 @@ func TestWatcher_IgnoresNonMatchingChange(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
 
 	src.events <- Event{Path: "README.md"}
 	// Give the loop time to (not) react.
@@ -94,7 +98,9 @@ func TestWatcher_DebouncesBurst(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
 
 	// A rapid burst should collapse into a single run.
 	for range 5 {
@@ -116,7 +122,7 @@ func TestWatcher_FailingOnChangeKeepsWatching(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
-		_ = w.Run(ctx, func(context.Context) error {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error {
 			atomic.AddInt32(&runs, 1)
 			return errors.New("boom")
 		})
@@ -136,7 +142,7 @@ func TestWatcher_StopsOnContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx, func(context.Context) error { return nil }) }()
+	go func() { done <- w.Run(ctx, func(_ context.Context, _ []string) error { return nil }) }()
 
 	cancel()
 	select {
@@ -155,9 +161,133 @@ func TestWatcher_SourceErrorIsNonFatal(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go func() { _ = w.Run(ctx, func(context.Context) error { atomic.AddInt32(&runs, 1); return nil }) }()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, _ []string) error { atomic.AddInt32(&runs, 1); return nil })
+	}()
 
 	src.errs <- errors.New("transient")
 	src.events <- Event{Path: "main.go"}
 	require.Eventually(t, func() bool { return atomic.LoadInt32(&runs) == 1 }, time.Second, 5*time.Millisecond)
+}
+
+// TestWatcher_AccumulatesFilesAcrossDebounce asserts that multiple events
+// within a single debounce window are deduplicated and passed to onChange as
+// a sorted slice.
+func TestWatcher_AccumulatesFilesAcrossDebounce(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	w := New([]string{"**/*.go"}, src,
+		WithDebounce(20*time.Millisecond),
+		WithInitialRun(false))
+
+	var (
+		mu       sync.Mutex
+		received [][]string
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, files []string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, append([]string(nil), files...))
+			return nil
+		})
+	}()
+
+	// Three events within the debounce window; one duplicate.
+	src.events <- Event{Path: "b.go"}
+	src.events <- Event{Path: "a.go"}
+	src.events <- Event{Path: "b.go"} // duplicate of the first
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"a.go", "b.go"}, received[0],
+		"files must be deduplicated and sorted")
+}
+
+// TestWatcher_ResetsAccumulatorBetweenTicks asserts that the accumulator does
+// NOT leak files from one tick into the next.
+func TestWatcher_ResetsAccumulatorBetweenTicks(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	w := New([]string{"**/*.go"}, src,
+		WithDebounce(20*time.Millisecond),
+		WithInitialRun(false))
+
+	var (
+		mu       sync.Mutex
+		received [][]string
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, files []string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, append([]string(nil), files...))
+			return nil
+		})
+	}()
+
+	src.events <- Event{Path: "a.go"}
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	src.events <- Event{Path: "c.go"}
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 2
+	}, time.Second, 5*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"a.go"}, received[0])
+	assert.Equal(t, []string{"c.go"}, received[1],
+		"second tick must not include first tick's files")
+}
+
+// TestWatcher_InitialRunPassesNilFiles pins the contract that the startup
+// (initial) tick conveys "no file triggered this" via a nil/empty files slice
+// — used by cmd/watch.go to suppress the watch.trigger event on initial run.
+func TestWatcher_InitialRunPassesNilFiles(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource()
+	w := New([]string{"**/*.go"}, src, WithInitialRun(true))
+
+	var (
+		mu     sync.Mutex
+		called bool
+		gotLen int
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		_ = w.Run(ctx, func(_ context.Context, files []string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			called = true
+			gotLen = len(files)
+			return nil
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return called
+	}, time.Second, 5*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 0, gotLen, "initial run must pass an empty/nil files slice")
 }


### PR DESCRIPTION
Closes #25.

## What

Wires the existing `--events` JSON event stream into `keepup watch`, adding one new event type — `watch.trigger {"files":[...]}` — emitted before each debounced re-run so consumers know which file changes caused the upcoming flow.

```
$ keepup watch ci --events -
{"event":"flow.start","flow":"ci","mode":"step"}
{"event":"group.end","group":"build","status":"ok","durationMs":1}
{"event":"flow.end","flow":"ci","status":"ok","durationMs":1}
{"event":"watch.trigger","files":["x.txt"]}
{"event":"flow.start","flow":"ci","mode":"step"}
{"event":"group.end","group":"build","status":"ok","durationMs":4}
{"event":"flow.end","flow":"ci","status":"ok","durationMs":4}
```

The first envelope is the startup run (no preceding `watch.trigger`); the trigger appears only before re-runs caused by file changes.

## How

- New `EventWatchTrigger` constant and `Files []string` field (omitempty) on the shared `engine.Event` struct — non-watch events stay JSON byte-identical (`run --events -` output is unchanged).
- `internal/watch.Watcher.Run`'s callback signature widens to `func(context.Context, []string) error`, passing the deduplicated, sorted list of matched paths accumulated during each debounce window (nil on the startup tick). The watch package stays event-agnostic.
- `cmd/watch.go` adds `--events`, reuses `openEventsWriter` from `cmd/root.go`, builds one shared `*JSONEmitter` for the whole watch session, and emits `watch.trigger` only when the batch was triggered by file changes. The per-tick `onChange` closure is extracted as `buildOnChange` so the production wiring and its test exercise the same code.

## Behavior change

The `"watching N dir(s)…"` banner moves from stdout to **stderr** — informational status belongs there, and this is what lets `--events -` produce JSON on stdout. Scripts that relied on the banner being on stdout (none in this repo) would read stderr instead.

## Tests / verification

Table-driven tests across `internal/engine` (event round-trip + omitempty regression), `internal/watch` (accumulation, dedup, reset-between-ticks, nil-on-initial-run), and `cmd` (banner-on-stderr regression + events wiring via the real `buildOnChange`). `go test -race ./...` and `golangci-lint run ./...` clean. Verified end-to-end with the real binary for: `run --events -` (no `files` key leaks), `watch --events -` (initial envelope → watch.trigger → re-run envelope; banner on stderr), and plain `watch` (no JSON on stdout).

Docs updated: README features row, `docs/USAGE.md` worked example, `docs/FAQ.md` Q&A.

## Out of scope (deferred)

- `watch.start` / `watch.stop` lifecycle events.
- Per-file event kind (created/modified/deleted) on `watch.trigger`.
