### PR TITLE
feat: multi-command groups via a polymorphic commands block

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -159,6 +159,9 @@ caching, gating, and output:
   the cache
 - `require`/`skip-if` gate the whole sequence, and templating expands each
   entry's command/params individually
+- `retries:` replays the **whole sequence** from the first command on each
+  attempt, and `timeout:` covers the whole sequence per attempt — keep
+  multi-command groups idempotent when combining them with retries
 
 Entries in a `commands:` list cannot reference each other's output: the group
 publishes a single combined output only after the whole sequence finishes, and

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -101,6 +101,8 @@ groups:
 | `skip-if`     | string     | no       | Predicate command; exit 0 skips the group (see [Gating](#gating-skip-if-and-require)).                                  |
 | `cache`       | map        | no       | Skip the group when declared inputs are unchanged (see [Caching](#caching)).                                            |
 
+*`command` is required unless the group declares `commands:` instead; the two are mutually exclusive.
+
 ### Direct exec vs. shell mode
 
 By default keepup spawns `command` with `params` as a real argv list — no

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -91,7 +91,8 @@ groups:
 | Field         | Type       | Required | Purpose                                                                                                                 |
 | ------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `name`        | string     | yes      | Unique identifier. Referenced from flows and `{{ output.X }}`.                                                          |
-| `command`     | string     | yes      | The program/argv0 to execute.                                                                                           |
+| `command`     | string     | yes*     | The program/argv0 to execute. Mutually exclusive with `commands`.                                                       |
+| `commands`    | list       | no       | Ordered list of commands run sequentially; see [Multi-command groups](#multi-command-groups). Mutually exclusive with `command`/`params`. |
 | `params`      | `[]string` | no       | Arguments. Passed as a real argv list — **no shell parsing** by default.                                                |
 | `env`         | map        | no       | Per-group env overrides; applied on top of the global `env`.                                                            |
 | `shell`       | string     | no       | When non-empty, the named shell program runs `command + params` as a single shell-interpreted line (opt-in shell mode). |
@@ -120,6 +121,48 @@ Use this only when you actually need shell features (pipes, expansions,
 
 On Windows, the shell flag is `/C` and the default shell falls back to
 `%COMSPEC%` or `cmd.exe`.
+
+### Multi-command groups
+
+A group may run an ordered **sequence** of commands instead of a single
+`command` + `params` pair. Each entry in `commands:` selects its execution
+mode by shape — the same string-or-map rule as dag `run:` entries:
+
+1. a `{command, params}` map — safe argv exec, never a shell (ignores `shell:`
+   even when it is set)
+2. a bare string — a shell command line; requires `shell:` on the group
+3. a multiline (`|`) string — a script piped to the shell as one unit;
+   requires `shell:`
+
+```yaml
+groups:
+  - name: ci
+    shell: bash # required only for the string/script entries below
+    commands:
+      - { command: go, params: [build, "./..."] } # safe argv exec (no shell)
+      - go test ./... # shell command line
+      - | # multiline script
+        ./scripts/lint.sh --strict
+        echo done
+```
+
+Commands run in declared order; the first non-zero exit stops the sequence
+and fails the group (like `set -e`). The group stays keepup's unit of
+caching, gating, and output:
+
+- the stored result's `output` is the combined output of all commands, in
+  order; `exitCode` is the first failing command's (0 when all succeed);
+  `durationMs` covers the whole sequence
+- `cache` fingerprints every command in the list — changing any entry busts
+  the cache
+- `require`/`skip-if` gate the whole sequence, and templating expands each
+  entry's command/params individually
+
+The singular `command`/`params` form remains first-class and is internally
+normalized to a one-element `commands:` list, so both forms share one
+execution path. Setting both `command` and `commands` on one group is a
+load error, as is a string-form entry on a group with no `shell:`, or an
+empty `commands:` list.
 
 ### Referencing other groups' output
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -160,6 +160,13 @@ caching, gating, and output:
 - `require`/`skip-if` gate the whole sequence, and templating expands each
   entry's command/params individually
 
+Entries in a `commands:` list cannot reference each other's output: the group
+publishes a single combined output only after the whole sequence finishes, and
+`{{ output "<this-group>" }}` inside one of its own entries is rejected at
+config load. To pipe one command's output into another within an entry, use a
+shell-form entry (`a | b`); to chain across cacheable units, split into
+separate groups.
+
 The singular `command`/`params` form remains first-class and is internally
 normalized to a one-element `commands:` list, so both forms share one
 execution path. Setting both `command` and `commands` on one group is a

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -41,6 +41,9 @@ func Compute(spec *config.Cache, commands []config.CommandSpec) (string, error) 
 	// Salt with the full command list and method so any changed command (or a
 	// form change: argv vs shell) busts the cache even when inputs are
 	// identical. v3 marks the multi-command fingerprint format.
+	// The \x00/\x01/\x02 sentinel encoding assumes config values are free of
+	// these control bytes (user's own config; a collision only mis-caches their
+	// own group).
 	fmt.Fprintf(h, "v3\x00%s\x00", spec.Method)
 	for _, c := range commands {
 		fmt.Fprintf(h, "%s\x00%t\x00", c.Command, c.IsShell)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,11 +19,10 @@ import (
 
 // Entry is a persisted cache record for one group.
 type Entry struct {
-	Fingerprint string           `json:"fingerprint"`
-	Result      result.RunResult `json:"result"`
-	Command     string           `json:"command"`
-	Params      []string         `json:"params"`
-	UpdatedAt   time.Time        `json:"updatedAt"`
+	Fingerprint string               `json:"fingerprint"`
+	Result      result.RunResult     `json:"result"`
+	Commands    []config.CommandSpec `json:"commands"`
+	UpdatedAt   time.Time            `json:"updatedAt"`
 }
 
 // Store loads and saves cache entries keyed by group name.
@@ -33,16 +32,22 @@ type Store interface {
 }
 
 // Compute returns a content fingerprint for the given cache spec. The
-// fingerprint changes when the method, command, params, or any matched
-// input file changes. A glob that matches nothing contributes nothing,
-// so adding the first matching file naturally changes the fingerprint.
-func Compute(spec *config.Cache, command string, params []string) (string, error) {
+// fingerprint changes when the method, any command/param/form in the group's
+// command list, or any matched input file changes. A glob that matches
+// nothing contributes nothing, so adding the first matching file naturally
+// changes the fingerprint.
+func Compute(spec *config.Cache, commands []config.CommandSpec) (string, error) {
 	h := sha256.New()
-	// Salt with command/params/method so a changed command busts the cache
-	// even when inputs are identical.
-	fmt.Fprintf(h, "v2\x00%s\x00%s\x00", spec.Method, command)
-	for _, p := range params {
-		fmt.Fprintf(h, "%s\x01", p)
+	// Salt with the full command list and method so any changed command (or a
+	// form change: argv vs shell) busts the cache even when inputs are
+	// identical. v3 marks the multi-command fingerprint format.
+	fmt.Fprintf(h, "v3\x00%s\x00", spec.Method)
+	for _, c := range commands {
+		fmt.Fprintf(h, "%s\x00%t\x00", c.Command, c.IsShell)
+		for _, p := range c.Params {
+			fmt.Fprintf(h, "%s\x01", p)
+		}
+		fmt.Fprintf(h, "\x02")
 	}
 
 	files, err := resolveGlobs(spec.Reads)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -33,10 +33,11 @@ type Store interface {
 
 // Compute returns a content fingerprint for the given cache spec. The
 // fingerprint changes when the method, any command/param/form in the group's
-// command list, or any matched input file changes. A glob that matches
+// command list, or any matched input file changes. For shell-form entries the
+// fingerprint also changes when the shell program changes. A glob that matches
 // nothing contributes nothing, so adding the first matching file naturally
 // changes the fingerprint.
-func Compute(spec *config.Cache, commands []config.CommandSpec) (string, error) {
+func Compute(spec *config.Cache, shell string, commands []config.CommandSpec) (string, error) {
 	h := sha256.New()
 	// Salt with the full command list and method so any changed command (or a
 	// form change: argv vs shell) busts the cache even when inputs are
@@ -47,6 +48,9 @@ func Compute(spec *config.Cache, commands []config.CommandSpec) (string, error) 
 	fmt.Fprintf(h, "v3\x00%s\x00", spec.Method)
 	for _, c := range commands {
 		fmt.Fprintf(h, "%s\x00%t\x00", c.Command, c.IsShell)
+		if c.IsShell {
+			fmt.Fprintf(h, "%s\x00", shell)
+		}
 		for _, p := range c.Params {
 			fmt.Fprintf(h, "%s\x01", p)
 		}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,10 +19,13 @@ import (
 
 // Entry is a persisted cache record for one group.
 type Entry struct {
-	Fingerprint string               `json:"fingerprint"`
-	Result      result.RunResult     `json:"result"`
-	Commands    []config.CommandSpec `json:"commands"`
-	UpdatedAt   time.Time            `json:"updatedAt"`
+	Fingerprint string           `json:"fingerprint"`
+	Result      result.RunResult `json:"result"`
+	// Commands records the expanded (post-template) command list that produced
+	// Result — resolved values, not the config's template text. This field is
+	// informational only: the Fingerprint (not Commands) decides cache hits.
+	Commands  []config.CommandSpec `json:"commands"`
+	UpdatedAt time.Time            `json:"updatedAt"`
 }
 
 // Store loads and saves cache entries keyed by group name.

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -26,44 +26,44 @@ func TestCompute_HashMethod(t *testing.T) {
 	writeFile(t, a, "package main\n")
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*.go")}}
 
-	fp1, err := Compute(spec, "go", []string{"build"})
+	fp1, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 	require.NoError(t, err)
 	assert.True(t, len(fp1) > 7 && fp1[:7] == "sha256:")
 
 	t.Run("stable when nothing changes", func(t *testing.T) {
-		fp2, err := Compute(spec, "go", []string{"build"})
+		fp2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.Equal(t, fp1, fp2)
 	})
 
 	t.Run("changes when content changes", func(t *testing.T) {
 		writeFile(t, a, "package main // changed\n")
-		fp2, err := Compute(spec, "go", []string{"build"})
+		fp2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fp1, fp2)
 	})
 
 	t.Run("changes when command changes", func(t *testing.T) {
-		fpCmd, err := Compute(spec, "gofmt", []string{"build"})
+		fpCmd, err := Compute(spec, []config.CommandSpec{{Command: "gofmt", Params: []string{"build"}}})
 		require.NoError(t, err)
-		fpCmd2, err := Compute(spec, "go", []string{"build"})
+		fpCmd2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fpCmd, fpCmd2)
 	})
 
 	t.Run("changes when params change", func(t *testing.T) {
-		fpA, err := Compute(spec, "go", []string{"build"})
+		fpA, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
-		fpB, err := Compute(spec, "go", []string{"test"})
+		fpB, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"test"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fpA, fpB)
 	})
 
 	t.Run("changes when a new matching file appears", func(t *testing.T) {
-		before, err := Compute(spec, "go", []string{"build"})
+		before, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		writeFile(t, filepath.Join(dir, "b.go"), "package main\n")
-		after, err := Compute(spec, "go", []string{"build"})
+		after, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, before, after)
 	})
@@ -75,13 +75,13 @@ func TestCompute_MtimeMethod(t *testing.T) {
 	writeFile(t, f, "hello")
 	spec := &config.Cache{Method: config.CacheMtime, Reads: []string{f}}
 
-	fp1, err := Compute(spec, "cat", nil)
+	fp1, err := Compute(spec, []config.CommandSpec{{Command: "cat"}})
 	require.NoError(t, err)
 
 	// Bumping mtime changes the fingerprint even if content is identical.
 	future := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(f, future, future))
-	fp2, err := Compute(spec, "cat", nil)
+	fp2, err := Compute(spec, []config.CommandSpec{{Command: "cat"}})
 	require.NoError(t, err)
 	assert.NotEqual(t, fp1, fp2)
 }
@@ -90,7 +90,7 @@ func TestCompute_DoublestarRecursive(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "pkg", "deep", "x.go"), "package deep\n")
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "**", "*.go")}}
-	fp, err := Compute(spec, "go", nil)
+	fp, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
 	require.NoError(t, err)
 	assert.Contains(t, fp, "sha256:")
 }
@@ -99,7 +99,7 @@ func TestCompute_MissingExplicitFileErrors(t *testing.T) {
 	// A literal (non-glob) path that doesn't exist should surface an error,
 	// since the user named a specific input.
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"/no/such/explicit/file.go"}}
-	_, err := Compute(spec, "go", nil)
+	_, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
 	// doublestar treats a literal path as a pattern matching nothing, so this
 	// resolves to zero files and succeeds; assert the no-op behavior.
 	require.NoError(t, err)
@@ -111,14 +111,14 @@ func TestCompute_DirectoryInput(t *testing.T) {
 	sub := filepath.Join(dir, "sub")
 	require.NoError(t, os.MkdirAll(sub, 0o755))
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*")}}
-	fp, err := Compute(spec, "go", nil)
+	fp, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
 	require.NoError(t, err)
 	assert.Contains(t, fp, "sha256:")
 }
 
 func TestCompute_BadGlobErrors(t *testing.T) {
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"[invalid"}}
-	_, err := Compute(spec, "go", nil)
+	_, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bad glob")
 }
@@ -164,8 +164,7 @@ func TestFileStore_RoundTrip(t *testing.T) {
 	entry := &Entry{
 		Fingerprint: "sha256:abc",
 		Result:      result.RunResult{Output: "done\n"},
-		Command:     "go",
-		Params:      []string{"build"},
+		Commands:    []config.CommandSpec{{Command: "go", Params: []string{"build"}}},
 		UpdatedAt:   time.Now(),
 	}
 	require.NoError(t, store.Save("build", entry))
@@ -211,8 +210,7 @@ func TestEntryRoundTripWithRunResult(t *testing.T) {
 			DurationMs: 12,
 			Status:     "ok",
 		},
-		Command:   "echo",
-		Params:    []string{"hi"},
+		Commands:  []config.CommandSpec{{Command: "echo", Params: []string{"hi"}}},
 		UpdatedAt: time.Now().UTC().Truncate(time.Second),
 	}
 	require.NoError(t, s.Save("g", want))
@@ -222,20 +220,73 @@ func TestEntryRoundTripWithRunResult(t *testing.T) {
 	assert.Equal(t, want.Fingerprint, got.Fingerprint)
 }
 
-// TestComputeUsesV2Salt confirms the fingerprint salt is v2, which
-// ensures every v1 cached fingerprint becomes a miss on first run after
-// the upgrade.
-func TestComputeUsesV2Salt(t *testing.T) {
+// TestComputeUsesV3Salt confirms the fingerprint salt is v3 (the
+// multi-command fingerprint format), which ensures every pre-v3 cached
+// fingerprint becomes a miss on first run after the upgrade.
+func TestComputeUsesV3Salt(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o600))
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "f.txt")}}
-	fp, err := Compute(spec, "echo", []string{"a"})
+	fp, err := Compute(spec, []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(fp, "sha256:"))
 
 	// Determinism: identical inputs produce identical fingerprints.
-	fp2, err := Compute(spec, "echo", []string{"a"})
+	fp2, err := Compute(spec, []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
 	require.NoError(t, err)
 	assert.Equal(t, fp, fp2)
+}
+
+func TestCompute_CommandListFingerprint(t *testing.T) {
+	spec := &config.Cache{Method: config.CacheHash, Reads: []string{}}
+	base := []config.CommandSpec{
+		{Command: "go", Params: []string{"build"}},
+		{Command: "go test ./...", IsShell: true},
+	}
+
+	fp1, err := Compute(spec, base)
+	require.NoError(t, err)
+
+	t.Run("identical lists hit", func(t *testing.T) {
+		fp2, err := Compute(spec, []config.CommandSpec{
+			{Command: "go", Params: []string{"build"}},
+			{Command: "go test ./...", IsShell: true},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, fp1, fp2)
+	})
+
+	t.Run("changing any command busts", func(t *testing.T) {
+		fp2, err := Compute(spec, []config.CommandSpec{
+			{Command: "go", Params: []string{"build"}},
+			{Command: "go vet ./...", IsShell: true}, // second entry changed
+		})
+		require.NoError(t, err)
+		assert.NotEqual(t, fp1, fp2)
+	})
+
+	t.Run("changing a param busts", func(t *testing.T) {
+		fp2, err := Compute(spec, []config.CommandSpec{
+			{Command: "go", Params: []string{"install"}},
+			{Command: "go test ./...", IsShell: true},
+		})
+		require.NoError(t, err)
+		assert.NotEqual(t, fp1, fp2)
+	})
+
+	t.Run("changing entry form (argv vs shell) busts", func(t *testing.T) {
+		fp2, err := Compute(spec, []config.CommandSpec{
+			{Command: "go", Params: []string{"build"}},
+			{Command: "go test ./...", IsShell: false}, // same text, argv form
+		})
+		require.NoError(t, err)
+		assert.NotEqual(t, fp1, fp2)
+	})
+
+	t.Run("adding an entry busts", func(t *testing.T) {
+		fp2, err := Compute(spec, append(base, config.CommandSpec{Command: "true"}))
+		require.NoError(t, err)
+		assert.NotEqual(t, fp1, fp2)
+	})
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -26,44 +26,44 @@ func TestCompute_HashMethod(t *testing.T) {
 	writeFile(t, a, "package main\n")
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*.go")}}
 
-	fp1, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+	fp1, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 	require.NoError(t, err)
 	assert.True(t, len(fp1) > 7 && fp1[:7] == "sha256:")
 
 	t.Run("stable when nothing changes", func(t *testing.T) {
-		fp2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		fp2, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.Equal(t, fp1, fp2)
 	})
 
 	t.Run("changes when content changes", func(t *testing.T) {
 		writeFile(t, a, "package main // changed\n")
-		fp2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		fp2, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fp1, fp2)
 	})
 
 	t.Run("changes when command changes", func(t *testing.T) {
-		fpCmd, err := Compute(spec, []config.CommandSpec{{Command: "gofmt", Params: []string{"build"}}})
+		fpCmd, err := Compute(spec, "", []config.CommandSpec{{Command: "gofmt", Params: []string{"build"}}})
 		require.NoError(t, err)
-		fpCmd2, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		fpCmd2, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fpCmd, fpCmd2)
 	})
 
 	t.Run("changes when params change", func(t *testing.T) {
-		fpA, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		fpA, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
-		fpB, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"test"}}})
+		fpB, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"test"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, fpA, fpB)
 	})
 
 	t.Run("changes when a new matching file appears", func(t *testing.T) {
-		before, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		before, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		writeFile(t, filepath.Join(dir, "b.go"), "package main\n")
-		after, err := Compute(spec, []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
+		after, err := Compute(spec, "", []config.CommandSpec{{Command: "go", Params: []string{"build"}}})
 		require.NoError(t, err)
 		assert.NotEqual(t, before, after)
 	})
@@ -75,13 +75,13 @@ func TestCompute_MtimeMethod(t *testing.T) {
 	writeFile(t, f, "hello")
 	spec := &config.Cache{Method: config.CacheMtime, Reads: []string{f}}
 
-	fp1, err := Compute(spec, []config.CommandSpec{{Command: "cat"}})
+	fp1, err := Compute(spec, "", []config.CommandSpec{{Command: "cat"}})
 	require.NoError(t, err)
 
 	// Bumping mtime changes the fingerprint even if content is identical.
 	future := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(f, future, future))
-	fp2, err := Compute(spec, []config.CommandSpec{{Command: "cat"}})
+	fp2, err := Compute(spec, "", []config.CommandSpec{{Command: "cat"}})
 	require.NoError(t, err)
 	assert.NotEqual(t, fp1, fp2)
 }
@@ -90,7 +90,7 @@ func TestCompute_DoublestarRecursive(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "pkg", "deep", "x.go"), "package deep\n")
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "**", "*.go")}}
-	fp, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
+	fp, err := Compute(spec, "", []config.CommandSpec{{Command: "go"}})
 	require.NoError(t, err)
 	assert.Contains(t, fp, "sha256:")
 }
@@ -99,7 +99,7 @@ func TestCompute_MissingExplicitFileErrors(t *testing.T) {
 	// A literal (non-glob) path that doesn't exist should surface an error,
 	// since the user named a specific input.
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"/no/such/explicit/file.go"}}
-	_, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
+	_, err := Compute(spec, "", []config.CommandSpec{{Command: "go"}})
 	// doublestar treats a literal path as a pattern matching nothing, so this
 	// resolves to zero files and succeeds; assert the no-op behavior.
 	require.NoError(t, err)
@@ -111,14 +111,14 @@ func TestCompute_DirectoryInput(t *testing.T) {
 	sub := filepath.Join(dir, "sub")
 	require.NoError(t, os.MkdirAll(sub, 0o755))
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "*")}}
-	fp, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
+	fp, err := Compute(spec, "", []config.CommandSpec{{Command: "go"}})
 	require.NoError(t, err)
 	assert.Contains(t, fp, "sha256:")
 }
 
 func TestCompute_BadGlobErrors(t *testing.T) {
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{"[invalid"}}
-	_, err := Compute(spec, []config.CommandSpec{{Command: "go"}})
+	_, err := Compute(spec, "", []config.CommandSpec{{Command: "go"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bad glob")
 }
@@ -228,12 +228,12 @@ func TestComputeUsesV3Salt(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o600))
 	spec := &config.Cache{Method: config.CacheHash, Reads: []string{filepath.Join(dir, "f.txt")}}
-	fp, err := Compute(spec, []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
+	fp, err := Compute(spec, "", []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(fp, "sha256:"))
 
 	// Determinism: identical inputs produce identical fingerprints.
-	fp2, err := Compute(spec, []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
+	fp2, err := Compute(spec, "", []config.CommandSpec{{Command: "echo", Params: []string{"a"}}})
 	require.NoError(t, err)
 	assert.Equal(t, fp, fp2)
 }
@@ -245,11 +245,11 @@ func TestCompute_CommandListFingerprint(t *testing.T) {
 		{Command: "go test ./...", IsShell: true},
 	}
 
-	fp1, err := Compute(spec, base)
+	fp1, err := Compute(spec, "sh", base)
 	require.NoError(t, err)
 
 	t.Run("identical lists hit", func(t *testing.T) {
-		fp2, err := Compute(spec, []config.CommandSpec{
+		fp2, err := Compute(spec, "sh", []config.CommandSpec{
 			{Command: "go", Params: []string{"build"}},
 			{Command: "go test ./...", IsShell: true},
 		})
@@ -258,7 +258,7 @@ func TestCompute_CommandListFingerprint(t *testing.T) {
 	})
 
 	t.Run("changing any command busts", func(t *testing.T) {
-		fp2, err := Compute(spec, []config.CommandSpec{
+		fp2, err := Compute(spec, "sh", []config.CommandSpec{
 			{Command: "go", Params: []string{"build"}},
 			{Command: "go vet ./...", IsShell: true}, // second entry changed
 		})
@@ -267,7 +267,7 @@ func TestCompute_CommandListFingerprint(t *testing.T) {
 	})
 
 	t.Run("changing a param busts", func(t *testing.T) {
-		fp2, err := Compute(spec, []config.CommandSpec{
+		fp2, err := Compute(spec, "sh", []config.CommandSpec{
 			{Command: "go", Params: []string{"install"}},
 			{Command: "go test ./...", IsShell: true},
 		})
@@ -276,7 +276,7 @@ func TestCompute_CommandListFingerprint(t *testing.T) {
 	})
 
 	t.Run("changing entry form (argv vs shell) busts", func(t *testing.T) {
-		fp2, err := Compute(spec, []config.CommandSpec{
+		fp2, err := Compute(spec, "sh", []config.CommandSpec{
 			{Command: "go", Params: []string{"build"}},
 			{Command: "go test ./...", IsShell: false}, // same text, argv form
 		})
@@ -285,8 +285,30 @@ func TestCompute_CommandListFingerprint(t *testing.T) {
 	})
 
 	t.Run("adding an entry busts", func(t *testing.T) {
-		fp2, err := Compute(spec, append(base, config.CommandSpec{Command: "true"}))
+		fp2, err := Compute(spec, "sh", append(base, config.CommandSpec{Command: "true"}))
 		require.NoError(t, err)
 		assert.NotEqual(t, fp1, fp2)
+	})
+
+	t.Run("changing the shell busts shell-form entries", func(t *testing.T) {
+		list := []config.CommandSpec{
+			{Command: "go test ./...", IsShell: true},
+		}
+		fpBash, err := Compute(spec, "bash", list)
+		require.NoError(t, err)
+		fpZsh, err := Compute(spec, "zsh", list)
+		require.NoError(t, err)
+		assert.NotEqual(t, fpBash, fpZsh)
+	})
+
+	t.Run("changing the shell does not bust argv-only lists", func(t *testing.T) {
+		list := []config.CommandSpec{
+			{Command: "go", Params: []string{"build"}},
+		}
+		fpBash, err := Compute(spec, "bash", list)
+		require.NoError(t, err)
+		fpZsh, err := Compute(spec, "zsh", list)
+		require.NoError(t, err)
+		assert.Equal(t, fpBash, fpZsh)
 	})
 }

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -257,3 +257,34 @@ flows:
 		})
 	}
 }
+
+func TestExtractRefs_CommandsEntries(t *testing.T) {
+	g := &Group{Name: "g", Shell: "sh", Commands: []CommandSpec{
+		{Command: "echo", Params: []string{`{{ output "a" }}`}},
+		{Command: `echo {{ output "b" }}`, IsShell: true},
+	}}
+	refs, err := ExtractRefs(g)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, refs)
+}
+
+func TestValidateReferences_CommandsEntryForwardRef(t *testing.T) {
+	yml := `
+version: 2
+groups:
+  - name: first
+    shell: sh
+    commands:
+      - echo {{ output "second" }}
+  - name: second
+    command: echo
+flows:
+  f:
+    steps:
+      - run: [first]
+      - run: [second]
+`
+	_, err := NewConfig([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not produced by an earlier step")
+}

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -289,6 +289,69 @@ flows:
 	assert.Contains(t, err.Error(), "not produced by an earlier step")
 }
 
+// selfRefYAML wraps a group body in a minimal step-mode config.
+func selfRefYAML(groupBody string) string {
+	return "version: 2\ngroups:\n" + groupBody + `
+flows:
+  f:
+    steps:
+      - run: [self]
+`
+}
+
+// selfRefDAGYAML wraps a group body in a minimal dag-mode config.
+func selfRefDAGYAML(groupBody string) string {
+	return "version: 2\ngroups:\n" + groupBody + `
+flows:
+  f:
+    mode: dag
+    run: [self]
+`
+}
+
+func TestValidateReferences_StepSelfRef_MultiGroup(t *testing.T) {
+	yml := selfRefYAML(`  - name: self
+    shell: sh
+    commands:
+      - echo hi
+      - echo {{ output "self" }}
+`)
+	_, err := NewConfig([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "references its own output",
+		"self-ref error must mention the key phrase")
+	assert.Contains(t, err.Error(), "cannot consume each other",
+		"multi-command group self-ref must include the guidance hint")
+}
+
+func TestValidateReferences_DAGSelfRef_MultiGroup(t *testing.T) {
+	yml := selfRefDAGYAML(`  - name: self
+    shell: sh
+    commands:
+      - echo hi
+      - echo {{ output "self" }}
+`)
+	_, err := NewConfig([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "references its own output",
+		"dag self-ref error must mention the key phrase")
+	assert.Contains(t, err.Error(), "cannot consume each other",
+		"multi-command group dag self-ref must include the guidance hint")
+}
+
+func TestValidateReferences_DAGSelfRef_SingularGroup(t *testing.T) {
+	yml := selfRefDAGYAML(`  - name: self
+    shell: sh
+    command: echo {{ output "self" }}
+`)
+	_, err := NewConfig([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "references its own output",
+		"singular group dag self-ref error must mention the key phrase")
+	assert.NotContains(t, err.Error(), "cannot consume each other",
+		"singular group must not include the multi-command hint")
+}
+
 func TestLoadConfig_CommandsFixture(t *testing.T) {
 	cfg, err := LoadConfig("./test-resources/config-commands-valid.yml")
 	require.NoError(t, err)

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestCommandSpec_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		want    CommandSpec
+		wantErr string
+	}{
+		{
+			name: "argv map form",
+			yaml: `{command: go, params: [build, "./..."]}`,
+			want: CommandSpec{Command: "go", Params: []string{"build", "./..."}, IsShell: false},
+		},
+		{
+			name: "argv map form without params",
+			yaml: `{command: ls}`,
+			want: CommandSpec{Command: "ls", IsShell: false},
+		},
+		{
+			name: "bare string form is shell",
+			yaml: `go test ./...`,
+			want: CommandSpec{Command: "go test ./...", IsShell: true},
+		},
+		{
+			name: "multiline script form is shell",
+			yaml: "|\n  echo one\n  echo two\n",
+			want: CommandSpec{Command: "echo one\necho two\n", IsShell: true},
+		},
+		{
+			name:    "empty string entry rejected",
+			yaml:    `""`,
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "map entry with empty command rejected",
+			yaml:    `{command: "", params: [x]}`,
+			wantErr: `missing or empty "command"`,
+		},
+		{
+			name:    "map entry missing command rejected",
+			yaml:    `{params: [x]}`,
+			wantErr: `missing or empty "command"`,
+		},
+		{
+			name:    "unexpected key rejected",
+			yaml:    `{command: go, shell: bash}`,
+			wantErr: `unexpected key "shell"`,
+		},
+		{
+			name:    "params must be a string list",
+			yaml:    `{command: go, params: 5}`,
+			wantErr: `"params" must be a list of strings`,
+		},
+		{
+			name:    "sequence entry rejected",
+			yaml:    `[a, b]`,
+			wantErr: "must be a string or a {command, params} map",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var cs CommandSpec
+			err := yaml.Unmarshal([]byte(tc.yaml), &cs)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cs)
+		})
+	}
+}

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -163,3 +163,97 @@ flows:
 		[]CommandSpec{{Command: "echo", Params: []string{"hi"}}},
 		single.CommandList())
 }
+
+func TestNewConfig_CommandsValidation(t *testing.T) {
+	// wrap builds a minimal valid config around one group body.
+	wrap := func(groupYAML string) string {
+		return "version: 2\ngroups:\n" + groupYAML + `
+flows:
+  f:
+    steps:
+      - run: [g]
+`
+	}
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "both command and commands rejected",
+			yaml: wrap(`  - name: g
+    command: echo
+    commands:
+      - { command: echo, params: [x] }
+`),
+			wantErr: "set either 'command' or 'commands', not both",
+		},
+		{
+			name: "params alongside commands rejected",
+			yaml: wrap(`  - name: g
+    params: [x]
+    commands:
+      - { command: echo }
+`),
+			wantErr: "set either 'command' or 'commands', not both",
+		},
+		{
+			name: "explicitly empty commands list rejected",
+			yaml: wrap(`  - name: g
+    commands: []
+`),
+			wantErr: "'commands' must list at least one entry",
+		},
+		{
+			name:    "neither command nor commands rejected",
+			yaml:    wrap("  - name: g\n"),
+			wantErr: "missing command",
+		},
+		{
+			name: "string entry without shell rejected",
+			yaml: wrap(`  - name: g
+    commands:
+      - { command: echo, params: [x] }
+      - echo hi
+`),
+			wantErr: "commands[2] is a shell command line but 'shell' is not set",
+		},
+		{
+			name: "script entry without shell rejected",
+			yaml: wrap(`  - name: g
+    commands:
+      - |
+        echo one
+        echo two
+`),
+			wantErr: "commands[1] is a shell command line but 'shell' is not set",
+		},
+		{
+			name: "argv-only list without shell is fine",
+			yaml: wrap(`  - name: g
+    commands:
+      - { command: echo, params: [a] }
+      - { command: echo, params: [b] }
+`),
+		},
+		{
+			name: "string entries with shell are fine",
+			yaml: wrap(`  - name: g
+    shell: sh
+    commands:
+      - echo hi
+`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewConfig([]byte(tc.yaml))
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -288,3 +288,22 @@ flows:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not produced by an earlier step")
 }
+
+func TestLoadConfig_CommandsFixture(t *testing.T) {
+	cfg, err := LoadConfig("./test-resources/config-commands-valid.yml")
+	require.NoError(t, err)
+
+	multi := cfg.GroupByName("multi")
+	require.NotNil(t, multi)
+	list := multi.CommandList()
+	require.Len(t, list, 3)
+	assert.False(t, list[0].IsShell)
+	assert.True(t, list[1].IsShell)
+	assert.True(t, list[2].IsShell)
+
+	single := cfg.GroupByName("single")
+	require.NotNil(t, single)
+	assert.Equal(t,
+		[]CommandSpec{{Command: "echo", Params: []string{"single-step"}}},
+		single.CommandList())
+}

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -81,3 +81,85 @@ func TestCommandSpec_UnmarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestGroup_CommandList(t *testing.T) {
+	tests := []struct {
+		name  string
+		group Group
+		want  []CommandSpec
+	}{
+		{
+			name:  "singular exec form normalizes to one safe-exec entry",
+			group: Group{Name: "g", Command: "echo", Params: []string{"hi"}},
+			want:  []CommandSpec{{Command: "echo", Params: []string{"hi"}, IsShell: false}},
+		},
+		{
+			name:  "singular shell form normalizes to one shell entry",
+			group: Group{Name: "g", Command: "brew", Params: []string{"update", "-v"}, Shell: "bash"},
+			want:  []CommandSpec{{Command: "brew", Params: []string{"update", "-v"}, IsShell: true}},
+		},
+		{
+			name: "commands list is returned as-is",
+			group: Group{Name: "g", Shell: "sh", Commands: []CommandSpec{
+				{Command: "go", Params: []string{"build"}},
+				{Command: "go test ./...", IsShell: true},
+			}},
+			want: []CommandSpec{
+				{Command: "go", Params: []string{"build"}},
+				{Command: "go test ./...", IsShell: true},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.group.CommandList())
+		})
+	}
+}
+
+func TestNewConfig_CommandsParsing(t *testing.T) {
+	yml := `
+version: 2
+groups:
+  - name: ci
+    shell: sh
+    commands:
+      - { command: go, params: [build, "./..."] }
+      - go test ./...
+      - |
+        echo one
+        echo two
+  - name: multi-argv
+    commands:
+      - { command: echo, params: [a] }
+      - { command: echo, params: [b] }
+  - name: single
+    command: echo
+    params: [hi]
+flows:
+  f:
+    steps:
+      - run: [ci, multi-argv, single]
+`
+	cfg, err := NewConfig([]byte(yml))
+	require.NoError(t, err)
+
+	ci := cfg.GroupByName("ci")
+	require.NotNil(t, ci)
+	require.Len(t, ci.CommandList(), 3)
+	assert.Equal(t, CommandSpec{Command: "go", Params: []string{"build", "./..."}}, ci.CommandList()[0])
+	assert.Equal(t, CommandSpec{Command: "go test ./...", IsShell: true}, ci.CommandList()[1])
+	assert.True(t, ci.CommandList()[2].IsShell)
+	assert.Equal(t, "echo one\necho two\n", ci.CommandList()[2].Command)
+
+	// multiple argv entries need no shell:
+	argv := cfg.GroupByName("multi-argv")
+	require.NotNil(t, argv)
+	require.Len(t, argv.CommandList(), 2)
+
+	single := cfg.GroupByName("single")
+	require.NotNil(t, single)
+	assert.Equal(t,
+		[]CommandSpec{{Command: "echo", Params: []string{"hi"}}},
+		single.CommandList())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,9 +76,16 @@ type Settings struct {
 // Group is an atomic, reusable command unit. Groups know nothing about flows;
 // composition lives in Flow.
 //
-// Shell controls how the command is launched:
+// A group runs either a single command (Command + Params) or an ordered
+// Commands list; the two are mutually exclusive and both normalize to
+// CommandList() so the engine has a single execution path.
+//
+// Shell controls how string-form commands are launched:
 //   - empty: exec directly with Params as argv (safe; no shell interpretation)
-//   - non-empty: pipe `command + params` through the named shell program (opt-in).
+//   - non-empty: pipe the command line through the named shell program (opt-in).
+//
+// In a Commands list, {command, params} entries are always safe argv exec and
+// ignore Shell; string entries require Shell to be set.
 //
 // Gating (Require, SkipIf) and Cache are optional short-circuits evaluated
 // before the command runs; see the engine for ordering semantics.
@@ -86,6 +93,7 @@ type Group struct {
 	Name        string            `yaml:"name"`
 	Command     string            `yaml:"command"`
 	Params      []string          `yaml:"params,omitempty"`
+	Commands    []CommandSpec     `yaml:"commands,omitempty"`
 	Shell       string            `yaml:"shell,omitempty"`
 	Description string            `yaml:"description,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty"`
@@ -104,6 +112,18 @@ type Cache struct {
 
 // UseShell reports whether the group opted into shell mode.
 func (g *Group) UseShell() bool { return g.Shell != "" }
+
+// CommandList returns the group's commands as a normalized list. When
+// commands: is set it is returned as-is; otherwise the singular
+// command/params pair becomes a one-element list whose shell-ness mirrors
+// UseShell(). The engine, cache, and reference extraction all consume this
+// accessor so singular and multi groups share a single execution path.
+func (g *Group) CommandList() []CommandSpec {
+	if len(g.Commands) > 0 {
+		return g.Commands
+	}
+	return []CommandSpec{{Command: g.Command, Params: g.Params, IsShell: g.UseShell()}}
+}
 
 // Flow is a named pipeline composed of groups.
 //

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -330,8 +330,8 @@ func (c *Config) indexGroups() (map[string]*Group, error) {
 		if g.Name == "" {
 			return nil, fmt.Errorf("groups[%d]: missing name", i)
 		}
-		if g.Command == "" {
-			return nil, fmt.Errorf("groups[%d] %q: missing command", i, g.Name)
+		if err := validateGroupCommands(i, g); err != nil {
+			return nil, err
 		}
 		if _, dup := out[g.Name]; dup {
 			return nil, fmt.Errorf("groups: duplicate name %q", g.Name)
@@ -359,6 +359,32 @@ func validateCache(g *Group) error {
 		// ok
 	default:
 		return fmt.Errorf("group %q: unknown cache.method %q (use 'hash' or 'mtime')", g.Name, g.Cache.Method)
+	}
+	return nil
+}
+
+// validateGroupCommands enforces the singular-vs-list contract:
+// command/params and commands: are mutually exclusive, the group must
+// declare at least one command, and string-form entries (shell command
+// lines / scripts) require shell: to be set. A nil Commands slice means the
+// key was absent; an empty non-nil slice means an explicit `commands: []`.
+func validateGroupCommands(i int, g *Group) error {
+	hasSingular := g.Command != "" || len(g.Params) > 0
+	switch {
+	case hasSingular && g.Commands != nil:
+		return fmt.Errorf("groups[%d] %q: set either 'command' or 'commands', not both", i, g.Name)
+	case g.Commands == nil && g.Command == "":
+		return fmt.Errorf("groups[%d] %q: missing command", i, g.Name)
+	case g.Commands != nil && len(g.Commands) == 0:
+		return fmt.Errorf("groups[%d] %q: 'commands' must list at least one entry", i, g.Name)
+	}
+	for j, cs := range g.Commands {
+		if cs.IsShell && !g.UseShell() {
+			return fmt.Errorf(
+				"groups[%d] %q: commands[%d] is a shell command line but 'shell' is not set",
+				i, g.Name, j+1,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,58 @@ func (r *RunEntry) UnmarshalYAML(node *yaml.Node) error {
 	return fmt.Errorf("run entry: must be a group name or a {group, when} map")
 }
 
+// CommandSpec is one entry in a group's commands: list. The YAML shape of the
+// entry selects its execution mode (same form-signals-mode rule as RunEntry):
+//   - a {command, params} mapping → safe argv exec, never a shell
+//   - a bare or multiline string  → a command line / script for the group's shell:
+type CommandSpec struct {
+	Command string   `yaml:"command" json:"command"`
+	Params  []string `yaml:"params,omitempty" json:"params,omitempty"`
+	// IsShell records that the entry was written in string form and therefore
+	// runs through the group's shell:. Argv-form entries always exec directly
+	// and ignore shell:, even when it is set.
+	IsShell bool `yaml:"-" json:"shell,omitempty"`
+}
+
+// UnmarshalYAML accepts a scalar (shell command line or script) or a
+// {command, params} mapping (safe argv exec). Any other shape, an empty
+// string, an empty command, or an unexpected key is a load error.
+func (cs *CommandSpec) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if strings.TrimSpace(node.Value) == "" {
+			return fmt.Errorf("commands entry: must not be empty")
+		}
+		cs.Command = node.Value
+		cs.IsShell = true
+		return nil
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			val := node.Content[i+1]
+			switch key {
+			case "command":
+				if val.Kind != yaml.ScalarNode {
+					return fmt.Errorf(`commands entry: "command" must be a string`)
+				}
+				cs.Command = val.Value
+			case "params":
+				if err := val.Decode(&cs.Params); err != nil {
+					return fmt.Errorf(`commands entry: "params" must be a list of strings: %w`, err)
+				}
+			default:
+				return fmt.Errorf("commands entry: unexpected key %q (use a string or a {command, params} map)", key)
+			}
+		}
+		if cs.Command == "" {
+			return fmt.Errorf(`commands entry: missing or empty "command"`)
+		}
+		return nil
+	default:
+		return fmt.Errorf("commands entry: must be a string or a {command, params} map")
+	}
+}
+
 // NewConfig parses YAML bytes into a Config and validates the schema.
 func NewConfig(b []byte) (*Config, error) {
 	var cfg Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,8 @@ func (g *Group) UseShell() bool { return g.Shell != "" }
 // command/params pair becomes a one-element list whose shell-ness mirrors
 // UseShell(). The engine, cache, and reference extraction all consume this
 // accessor so singular and multi groups share a single execution path.
+// The returned slice aliases the group's backing array and is intended for
+// read-only use; callers must not modify it.
 func (g *Group) CommandList() []CommandSpec {
 	if len(g.Commands) > 0 {
 		return g.Commands
@@ -225,6 +227,9 @@ type CommandSpec struct {
 func (cs *CommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
+		// Deliberately rejects whitespace-only strings (stricter than RunEntry's
+		// empty-only check) because a blank shell line is useless and likely a
+		// YAML indentation mistake.
 		if strings.TrimSpace(node.Value) == "" {
 			return fmt.Errorf("commands entry: must not be empty")
 		}
@@ -253,9 +258,10 @@ func (cs *CommandSpec) UnmarshalYAML(node *yaml.Node) error {
 			return fmt.Errorf(`commands entry: missing or empty "command"`)
 		}
 		return nil
-	default:
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
 		return fmt.Errorf("commands entry: must be a string or a {command, params} map")
 	}
+	return fmt.Errorf("commands entry: must be a string or a {command, params} map")
 }
 
 // NewConfig parses YAML bytes into a Config and validates the schema.

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -6,10 +6,11 @@ import (
 	"github.com/quike/keepup/internal/template"
 )
 
-// ExtractRefs returns every group name referenced by a group's command or
-// params via the template output() function (or the legacy "{{ output.X }}"
-// form). Duplicates are preserved by position. An error is returned when any
-// template string is malformed, surfacing the problem at config-load time.
+// ExtractRefs returns every group name referenced by a group's commands via
+// the template output() function (or the legacy "{{ output.X }}" form),
+// across every entry in CommandList(). Duplicates are preserved by position.
+// An error is returned when any template string is malformed, surfacing the
+// problem at config-load time.
 func ExtractRefs(g *Group) ([]string, error) {
 	out := make([]string, 0)
 	collect := func(s string) error {
@@ -20,12 +21,14 @@ func ExtractRefs(g *Group) ([]string, error) {
 		out = append(out, refs...)
 		return nil
 	}
-	if err := collect(g.Command); err != nil {
-		return nil, err
-	}
-	for _, p := range g.Params {
-		if err := collect(p); err != nil {
+	for _, cs := range g.CommandList() {
+		if err := collect(cs.Command); err != nil {
 			return nil, err
+		}
+		for _, p := range cs.Params {
+			if err := collect(p); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return out, nil

--- a/internal/config/refs.go
+++ b/internal/config/refs.go
@@ -34,6 +34,16 @@ func ExtractRefs(g *Group) ([]string, error) {
 	return out, nil
 }
 
+// selfRefHint explains the intra-group limitation for multi-command groups: a
+// commands: entry cannot consume an earlier entry's output, which is the
+// usual intent behind a self-reference.
+func selfRefHint(g *Group) string {
+	if g == nil || len(g.CommandList()) <= 1 {
+		return ""
+	}
+	return " (commands in a group cannot consume each other's output; split into separate groups or pipe within a single shell entry)"
+}
+
 // ValidateReferences runs strict-mode reference checks on every flow:
 //
 //   - every {{ output.X }} must point to a group that appears earlier in the
@@ -82,6 +92,12 @@ func (c *Config) checkStepRefs(flowName string, f *Flow, memberSet map[string]st
 				return fmt.Errorf("flow %q step %d: %w", flowName, stepIdx+1, err)
 			}
 			for _, ref := range refs {
+				if ref == member {
+					return fmt.Errorf(
+						"flow %q step %d: group %q references its own output%s",
+						flowName, stepIdx+1, member, selfRefHint(g),
+					)
+				}
 				if _, ok := memberSet[ref]; !ok {
 					return fmt.Errorf(
 						"flow %q step %d: group %q references {{ output.%s }}, but %q is not part of this flow",
@@ -152,7 +168,8 @@ func (c *Config) checkDAGRefs(flowName string, f *Flow, members []string, member
 			)
 		}
 		if ref == m {
-			return fmt.Errorf("flow %q: group %q references its own output", flowName, m)
+			return fmt.Errorf("flow %q: group %q references its own output%s",
+				flowName, m, selfRefHint(c.GroupByName(m)))
 		}
 		adj[ref] = append(adj[ref], m)
 		inDeg[m]++

--- a/internal/config/test-resources/config-commands-valid.yml
+++ b/internal/config/test-resources/config-commands-valid.yml
@@ -1,0 +1,32 @@
+version: 2
+
+settings:
+  logging:
+    level: info
+
+groups:
+  # multi-command group — all three entry forms, mixed
+  - name: multi
+    description: "Mixed-form command sequence"
+    shell: sh
+    commands:
+      - { command: echo, params: [argv-step] }
+      - echo shell-step
+      - |
+        echo script-line-1
+        echo script-line-2
+
+  # single-command group — unchanged, still terse
+  - name: single
+    description: "Singular form stays first-class"
+    command: echo
+    params: [single-step]
+
+flows:
+  ci:
+    description: "Multi then single"
+    steps:
+      - run: [multi]
+      - run: [single]
+
+default: ci

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -247,6 +247,41 @@ func TestEngine_CommandsFixture_EndToEnd(t *testing.T) {
 	assert.Equal(t, "single-step\n", single.Output)
 }
 
+func TestEngine_ErrorDecoration_SingularVsMulti(t *testing.T) {
+	t.Run("singular group error is not decorated", func(t *testing.T) {
+		g := config.Group{Name: "solo", Command: "boom"}
+		cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{"solo"}})
+		r := &specRunner{errs: map[string]error{"boom": assert.AnError}}
+		e := New(cfg, WithRunner(r))
+
+		err := e.RunFlow(context.Background(), "f")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "command 1 of 1",
+			"singular group must not get sequence decoration")
+		assert.Contains(t, err.Error(), assert.AnError.Error(),
+			"underlying error text must be preserved")
+	})
+
+	t.Run("multi-command group failure is decorated with position", func(t *testing.T) {
+		g := config.Group{
+			Name: "multi3",
+			Commands: []config.CommandSpec{
+				{Command: "first"},
+				{Command: "boom"},
+				{Command: "third"},
+			},
+		}
+		cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{"multi3"}})
+		r := &specRunner{errs: map[string]error{"boom": assert.AnError}}
+		e := New(cfg, WithRunner(r))
+
+		err := e.RunFlow(context.Background(), "f")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "command 2 of 3",
+			"multi-command failure must point into the sequence")
+	})
+}
+
 func TestEngine_MultiCommand_RealRunner(t *testing.T) {
 	skipOnWindows(t)
 

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -190,6 +190,25 @@ func TestEngine_MultiCommand_TemplatesExpandPerEntry(t *testing.T) {
 	assert.Equal(t, "use VAL", r.calls[2].command, "shell string expanded")
 }
 
+func TestEngine_CommandsFixture_EndToEnd(t *testing.T) {
+	skipOnWindows(t)
+
+	cfg, err := config.LoadConfig("../config/test-resources/config-commands-valid.yml")
+	require.NoError(t, err)
+
+	e := New(cfg, WithRunner(&ShellRunner{Stdout: io.Discard, Stderr: io.Discard}))
+	require.NoError(t, e.RunFlow(context.Background(), "ci"))
+
+	multi, ok := e.Outputs().Get("multi")
+	require.True(t, ok)
+	assert.Equal(t, "argv-step\nshell-step\nscript-line-1\nscript-line-2\n", multi.Output)
+	assert.Equal(t, 0, multi.ExitCode)
+
+	single, ok := e.Outputs().Get("single")
+	require.True(t, ok)
+	assert.Equal(t, "single-step\n", single.Output)
+}
+
 func TestEngine_MultiCommand_RealRunner(t *testing.T) {
 	skipOnWindows(t)
 

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -190,6 +190,44 @@ func TestEngine_MultiCommand_TemplatesExpandPerEntry(t *testing.T) {
 	assert.Equal(t, "use VAL", r.calls[2].command, "shell string expanded")
 }
 
+// softFailRunner returns (RunResult{Status:"failed", ExitCode:2}, nil) for the
+// first command and (RunResult{Status:StatusOK}, nil) for every subsequent
+// call. It is intentionally separate from specRunner so we can test the sticky
+// status contract without modifying that helper.
+type softFailRunner struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *softFailRunner) Run(_ context.Context, _ *config.Group, _ []string, _ map[string]string) (result.RunResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.calls == 1 {
+		return result.RunResult{Status: "failed", ExitCode: 2, DurationMs: 1}, nil
+	}
+	return result.RunResult{Status: result.StatusOK, DurationMs: 1}, nil
+}
+
+func TestRunSequence_StickyNonOKStatus(t *testing.T) {
+	g := config.Group{
+		Name: "sticky",
+		Commands: []config.CommandSpec{
+			{Command: "bad"},
+			{Command: "good"},
+		},
+	}
+	cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{"sticky"}})
+	r := &softFailRunner{}
+	e := New(cfg, WithRunner(r))
+
+	specs := g.CommandList()
+	out, err := e.runSequence(context.Background(), &g, specs)
+	require.NoError(t, err, "nil error: sequence continues when runner returns nil error")
+	assert.Equal(t, "failed", out.Status, "first non-ok status must survive a later ok command")
+	assert.Equal(t, 2, out.ExitCode, "exit code of first failing command is preserved")
+}
+
 func TestEngine_CommandsFixture_EndToEnd(t *testing.T) {
 	skipOnWindows(t)
 

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/quike/keepup/internal/template"
 )
 
-// specRunner records each command invocation (argv0, params, shell) and
-// returns scripted results keyed by argv0. failOnce entries fail the first
-// invocation of that command and succeed afterwards.
+// specRunner records each command invocation (command, params, shell) and
+// returns scripted results keyed by the full command string. failOnce entries
+// fail the first invocation of that command and succeed afterwards.
 type specRunner struct {
 	mu       sync.Mutex
 	calls    []specCall

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -1,0 +1,190 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quike/keepup/internal/config"
+	"github.com/quike/keepup/internal/result"
+	"github.com/quike/keepup/internal/template"
+)
+
+// specRunner records each command invocation (argv0, params, shell) and
+// returns scripted results keyed by argv0. failOnce entries fail the first
+// invocation of that command and succeed afterwards.
+type specRunner struct {
+	mu       sync.Mutex
+	calls    []specCall
+	outputs  map[string]string
+	errs     map[string]error
+	failOnce map[string]error
+}
+
+type specCall struct {
+	command string
+	params  []string
+	shell   string
+}
+
+func (f *specRunner) Run(_ context.Context, g *config.Group, params []string, _ map[string]string) (result.RunResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, specCall{command: g.Command, params: append([]string(nil), params...), shell: g.Shell})
+	out := f.outputs[g.Command]
+	rr := result.RunResult{Stdout: out, Output: out, Status: result.StatusOK, DurationMs: 1}
+	if err, ok := f.failOnce[g.Command]; ok {
+		delete(f.failOnce, g.Command)
+		rr.ExitCode = 1
+		return rr, err
+	}
+	if err, ok := f.errs[g.Command]; ok {
+		rr.ExitCode = 1
+		return rr, err
+	}
+	return rr, nil
+}
+
+func (f *specRunner) commandSeq() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	seq := make([]string, len(f.calls))
+	for i, c := range f.calls {
+		seq[i] = c.command
+	}
+	return seq
+}
+
+// multiGroup is the canonical mixed-form group used across these tests.
+func multiGroup() config.Group {
+	return config.Group{
+		Name:  "m",
+		Shell: "fakesh",
+		Commands: []config.CommandSpec{
+			{Command: "alpha", Params: []string{"-a"}},         // argv form
+			{Command: "beta line", IsShell: true},              // shell string form
+			{Command: "gamma one\ngamma two\n", IsShell: true}, // script form
+		},
+	}
+}
+
+func TestEngine_MultiCommand_RunsInOrderAndCombines(t *testing.T) {
+	cfg := stepFlowCfg(t, []config.Group{multiGroup()}, [][]string{{"m"}})
+	r := &specRunner{outputs: map[string]string{
+		"alpha":                  "A\n",
+		"beta line":              "B\n",
+		"gamma one\ngamma two\n": "C\n",
+	}}
+	e := New(cfg, WithRunner(r))
+
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+
+	assert.Equal(t, []string{"alpha", "beta line", "gamma one\ngamma two\n"}, r.commandSeq())
+	got, ok := e.Outputs().Get("m")
+	require.True(t, ok)
+	assert.Equal(t, "A\nB\nC\n", got.Output)
+	assert.Equal(t, "A\nB\nC\n", got.Stdout)
+	assert.Equal(t, 0, got.ExitCode)
+	assert.Equal(t, int64(3), got.DurationMs, "duration sums across the sequence")
+	assert.Equal(t, result.StatusOK, got.Status)
+}
+
+func TestEngine_MultiCommand_ArgvEntryIgnoresShell(t *testing.T) {
+	cfg := stepFlowCfg(t, []config.Group{multiGroup()}, [][]string{{"m"}})
+	r := &specRunner{outputs: map[string]string{}}
+	e := New(cfg, WithRunner(r))
+
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+
+	require.Len(t, r.calls, 3)
+	assert.Equal(t, "", r.calls[0].shell, "argv entry must clear shell even when group sets it")
+	assert.Equal(t, []string{"-a"}, r.calls[0].params)
+	assert.Equal(t, "fakesh", r.calls[1].shell, "string entry keeps the group shell")
+	assert.Empty(t, r.calls[1].params)
+	assert.Equal(t, "fakesh", r.calls[2].shell, "script entry keeps the group shell")
+}
+
+func TestEngine_MultiCommand_StopsOnFirstFailure(t *testing.T) {
+	cfg := stepFlowCfg(t, []config.Group{multiGroup()}, [][]string{{"m"}})
+	r := &specRunner{
+		outputs: map[string]string{"alpha": "A\n"},
+		errs:    map[string]error{"beta line": assert.AnError},
+	}
+	e := New(cfg, WithRunner(r))
+
+	err := e.RunFlow(context.Background(), "f")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command 2 of 3")
+	assert.Equal(t, []string{"alpha", "beta line"}, r.commandSeq(), "third command must not run")
+	_, ok := e.Outputs().Get("m")
+	assert.False(t, ok, "failed group stores no output")
+}
+
+func TestRunSequence_AggregatesExitCodeAndOutput(t *testing.T) {
+	r := &specRunner{
+		outputs: map[string]string{"alpha": "A\n"},
+		errs:    map[string]error{"beta line": assert.AnError},
+	}
+	g := multiGroup()
+	cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{"m"}})
+	e := New(cfg, WithRunner(r))
+
+	specs := g.CommandList()
+	out, err := e.runSequence(context.Background(), &g, specs)
+	require.Error(t, err)
+	assert.Equal(t, "A\n", out.Output, "combined output covers commands that ran")
+	assert.Equal(t, 1, out.ExitCode, "exit code is the first failing command's")
+	assert.Equal(t, int64(2), out.DurationMs)
+}
+
+func TestEngine_MultiCommand_RetryReplaysWholeSequence(t *testing.T) {
+	cfg := stepFlowCfg(t, []config.Group{multiGroup()}, [][]string{{"m"}})
+	cfg.Flows["f"] = config.Flow{
+		Mode:    config.ModeStep,
+		Steps:   []config.Step{{Run: []string{"m"}}},
+		Retries: 1,
+	}
+	r := &specRunner{
+		outputs:  map[string]string{},
+		failOnce: map[string]error{"beta line": assert.AnError},
+	}
+	e := New(cfg, WithRunner(r), WithRetryBackoff(0))
+
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Equal(t,
+		[]string{"alpha", "beta line", "alpha", "beta line", "gamma one\ngamma two\n"},
+		r.commandSeq(), "retry restarts from the first command")
+}
+
+func TestEngine_MultiCommand_DryRunRunsNothing(t *testing.T) {
+	cfg := stepFlowCfg(t, []config.Group{multiGroup()}, [][]string{{"m"}})
+	r := &specRunner{}
+	e := New(cfg, WithRunner(r), WithDryRun(true))
+
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	assert.Empty(t, r.calls)
+	got, ok := e.Outputs().Get("m")
+	require.True(t, ok)
+	assert.Equal(t, result.StatusDryRun, got.Status)
+}
+
+func TestEngine_MultiCommand_TemplatesExpandPerEntry(t *testing.T) {
+	groups := []config.Group{
+		{Name: "a", Command: "echo"},
+		{Name: "m2", Shell: "fakesh", Commands: []config.CommandSpec{
+			{Command: "echo", Params: []string{`{{ output "a" }}`}},
+			{Command: `use {{ output "a" }}`, IsShell: true},
+		}},
+	}
+	cfg := stepFlowCfg(t, groups, [][]string{{"a"}, {"m2"}})
+	r := &specRunner{outputs: map[string]string{"echo": "VAL\n"}}
+	e := New(cfg, WithRunner(r), WithExpander(template.NewExpander()))
+
+	require.NoError(t, e.RunFlow(context.Background(), "f"))
+	require.Len(t, r.calls, 3)
+	assert.Equal(t, []string{"VAL"}, r.calls[1].params, "argv param expanded")
+	assert.Equal(t, "use VAL", r.calls[2].command, "shell string expanded")
+}

--- a/internal/engine/commands_test.go
+++ b/internal/engine/commands_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"io"
 	"sync"
 	"testing"
 
@@ -187,4 +188,68 @@ func TestEngine_MultiCommand_TemplatesExpandPerEntry(t *testing.T) {
 	require.Len(t, r.calls, 3)
 	assert.Equal(t, []string{"VAL"}, r.calls[1].params, "argv param expanded")
 	assert.Equal(t, "use VAL", r.calls[2].command, "shell string expanded")
+}
+
+func TestEngine_MultiCommand_RealRunner(t *testing.T) {
+	skipOnWindows(t)
+
+	run := func(t *testing.T, g config.Group) (result.RunResult, error) {
+		t.Helper()
+		cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{g.Name}})
+		e := New(cfg, WithRunner(&ShellRunner{Stdout: io.Discard, Stderr: io.Discard}))
+		err := e.RunFlow(context.Background(), "f")
+		out, _ := e.Outputs().Get(g.Name)
+		return out, err
+	}
+
+	t.Run("argv entry stays safe-exec even with shell set", func(t *testing.T) {
+		out, err := run(t, config.Group{Name: "g", Shell: "sh", Commands: []config.CommandSpec{
+			{Command: "echo", Params: []string{"$(whoami)", "*"}},
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, "$(whoami) *\n", out.Output, "no shell interpretation, no glob expansion")
+	})
+
+	t.Run("bare string runs through the declared shell", func(t *testing.T) {
+		out, err := run(t, config.Group{Name: "g", Shell: "sh", Commands: []config.CommandSpec{
+			{Command: "printf 'hi' | tr h H", IsShell: true},
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, "Hi", out.Output, "pipes prove shell interpretation")
+	})
+
+	t.Run("multiline script runs as one script", func(t *testing.T) {
+		out, err := run(t, config.Group{Name: "g", Shell: "sh", Commands: []config.CommandSpec{
+			{Command: "X=fromscript\necho $X\n", IsShell: true},
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, "fromscript\n", out.Output, "variable spans lines: one script, not line-by-line")
+	})
+
+	t.Run("mixed forms interleave in order", func(t *testing.T) {
+		out, err := run(t, config.Group{Name: "g", Shell: "sh", Commands: []config.CommandSpec{
+			{Command: "echo", Params: []string{"one"}},
+			{Command: "echo two", IsShell: true},
+			{Command: "echo", Params: []string{"three"}},
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, "one\ntwo\nthree\n", out.Output)
+	})
+
+	t.Run("first non-zero exit stops the sequence", func(t *testing.T) {
+		g := config.Group{Name: "g", Shell: "sh", Commands: []config.CommandSpec{
+			{Command: "echo", Params: []string{"ran"}},
+			{Command: "exit 3", IsShell: true},
+			{Command: "echo", Params: []string{"never"}},
+		}}
+		cfg := stepFlowCfg(t, []config.Group{g}, [][]string{{"g"}})
+		e := New(cfg, WithRunner(&ShellRunner{Stdout: io.Discard, Stderr: io.Discard}))
+
+		out, err := e.runSequence(context.Background(), &g, g.CommandList())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "command 2 of 3")
+		assert.Equal(t, "ran\n", out.Output)
+		assert.Equal(t, 3, out.ExitCode, "exit code is the first failing command's")
+		assert.NotContains(t, out.Output, "never")
+	})
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -167,6 +167,29 @@ func resolveEnvelope(flow *config.Flow, step *config.Step) envelope {
 	return envelope{timeout: d, retries: retries}
 }
 
+// expandCommands renders every command in the group's normalized list against
+// the available outputs/env. The expanded specs are what the runner, cache,
+// and logs all see.
+func (e *Engine) expandCommands(group *config.Group, data template.Data) ([]config.CommandSpec, error) {
+	specs := group.CommandList()
+	expanded := make([]config.CommandSpec, len(specs))
+	for i, s := range specs {
+		cmd, err := e.expander.Expand(s.Command, data)
+		if err != nil {
+			return nil, fmt.Errorf("group %q: expand command: %w", group.Name, err)
+		}
+		params := make([]string, len(s.Params))
+		for j, p := range s.Params {
+			params[j], err = e.expander.Expand(p, data)
+			if err != nil {
+				return nil, fmt.Errorf("group %q: expand param %d: %w", group.Name, j+1, err)
+			}
+		}
+		expanded[i] = config.CommandSpec{Command: cmd, Params: params, IsShell: s.IsShell}
+	}
+	return expanded, nil
+}
+
 // runGroup decides whether and how to execute a group. The decision order is:
 //
 //  1. dry-run    → log intent, do nothing else (gating/cache are not evaluated)
@@ -194,25 +217,10 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	data := template.Data{Outputs: baseline, Env: e.cfg.Env}
 
-	// Expand every command in the group's normalized list against the
-	// available outputs/env. The expanded specs are what the runner, cache,
-	// and logs all see.
 	g := *group
-	specs := group.CommandList()
-	expanded := make([]config.CommandSpec, len(specs))
-	for i, s := range specs {
-		cmd, err := e.expander.Expand(s.Command, data)
-		if err != nil {
-			return fmt.Errorf("group %q: expand command: %w", group.Name, err)
-		}
-		params := make([]string, len(s.Params))
-		for j, p := range s.Params {
-			params[j], err = e.expander.Expand(p, data)
-			if err != nil {
-				return fmt.Errorf("group %q: expand param %d: %w", group.Name, j+1, err)
-			}
-		}
-		expanded[i] = config.CommandSpec{Command: cmd, Params: params, IsShell: s.IsShell}
+	expanded, err := e.expandCommands(group, data)
+	if err != nil {
+		return err
 	}
 
 	if e.dryRun {
@@ -269,7 +277,9 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 // timeout and retrying up to env.retries additional times on failure. A retry
 // replays the whole sequence from the first command. Backoff between attempts
 // respects ctx cancellation.
-func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, commands []config.CommandSpec, env envelope) (result.RunResult, error) {
+func (e *Engine) execWithEnvelope(
+	ctx context.Context, group *config.Group, commands []config.CommandSpec, env envelope,
+) (result.RunResult, error) {
 	attempts := 1 + env.retries
 	var (
 		out result.RunResult
@@ -309,6 +319,9 @@ func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, comm
 func (e *Engine) runSequence(ctx context.Context, group *config.Group, commands []config.CommandSpec) (result.RunResult, error) {
 	var agg result.RunResult
 	for i, s := range commands {
+		if err := ctx.Err(); err != nil {
+			return agg, err
+		}
 		sg := *group
 		sg.Command = s.Command
 		if !s.IsShell {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -297,7 +297,8 @@ func (e *Engine) cacheLookup(group *config.Group, params []string) (*cache.Entry
 	if e.noCache || group.Cache == nil {
 		return nil, false
 	}
-	fp, err := cache.Compute(group.Cache, group.Command, params)
+	fp, err := cache.Compute(group.Cache,
+		[]config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}})
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; running group", "group", group.Name, "err", err.Error())
 		return nil, false
@@ -317,7 +318,8 @@ func (e *Engine) cacheStore(group *config.Group, params []string, out *result.Ru
 	if e.noCache || group.Cache == nil {
 		return
 	}
-	fp, err := cache.Compute(group.Cache, group.Command, params)
+	fp, err := cache.Compute(group.Cache,
+		[]config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}})
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; not caching", "group", group.Name, "err", err.Error())
 		return
@@ -325,8 +327,7 @@ func (e *Engine) cacheStore(group *config.Group, params []string, out *result.Ru
 	entry := &cache.Entry{
 		Fingerprint: fp,
 		Result:      *out,
-		Command:     group.Command,
-		Params:      params,
+		Commands:    []config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}},
 		UpdatedAt:   time.Now(),
 	}
 	if err := e.cache.Save(group.Name, entry); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -194,27 +194,32 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	data := template.Data{Outputs: baseline, Env: e.cfg.Env}
 
-	// Expand the command and every param against the available outputs/env.
-	// A copy of the group carries the expanded command so the runner, cache,
-	// and logs all see the resolved value.
+	// Expand every command in the group's normalized list against the
+	// available outputs/env. The expanded specs are what the runner, cache,
+	// and logs all see.
 	g := *group
-	cmd, err := e.expander.Expand(group.Command, data)
-	if err != nil {
-		return fmt.Errorf("group %q: expand command: %w", group.Name, err)
-	}
-	g.Command = cmd
-
-	expanded := make([]string, len(group.Params))
-	for i, p := range group.Params {
-		expanded[i], err = e.expander.Expand(p, data)
+	specs := group.CommandList()
+	expanded := make([]config.CommandSpec, len(specs))
+	for i, s := range specs {
+		cmd, err := e.expander.Expand(s.Command, data)
 		if err != nil {
-			return fmt.Errorf("group %q: expand param %d: %w", group.Name, i+1, err)
+			return fmt.Errorf("group %q: expand command: %w", group.Name, err)
 		}
+		params := make([]string, len(s.Params))
+		for j, p := range s.Params {
+			params[j], err = e.expander.Expand(p, data)
+			if err != nil {
+				return fmt.Errorf("group %q: expand param %d: %w", group.Name, j+1, err)
+			}
+		}
+		expanded[i] = config.CommandSpec{Command: cmd, Params: params, IsShell: s.IsShell}
 	}
 
 	if e.dryRun {
-		e.log.Info("[dry-run] would run",
-			"group", g.Name, "command", g.Command, "params", expanded, "shell", g.UseShell())
+		for _, s := range expanded {
+			e.log.Info("[dry-run] would run",
+				"group", g.Name, "command", s.Command, "params", s.Params, "shell", s.IsShell)
+		}
 		e.outputs.Set(g.Name, result.RunResult{Status: result.StatusDryRun})
 		status = StatusDryRun
 		return nil
@@ -244,7 +249,9 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 		return nil
 	}
 
-	e.log.Info("running group", "group", g.Name, "command", g.Command, "params", expanded)
+	for _, s := range expanded {
+		e.log.Info("running group", "group", g.Name, "command", s.Command, "params", s.Params)
+	}
 	out, err := e.execWithEnvelope(ctx, &g, expanded, env)
 	if err != nil {
 		e.log.Error("group failed", "group", g.Name, "err", err.Error(), "output", out.Output)
@@ -258,10 +265,11 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	return nil
 }
 
-// execWithEnvelope runs the group's command, applying a per-attempt timeout and
-// retrying up to env.retries additional times on failure. Backoff between
-// attempts respects ctx cancellation.
-func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, params []string, env envelope) (result.RunResult, error) {
+// execWithEnvelope runs the group's command sequence, applying a per-attempt
+// timeout and retrying up to env.retries additional times on failure. A retry
+// replays the whole sequence from the first command. Backoff between attempts
+// respects ctx cancellation.
+func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, commands []config.CommandSpec, env envelope) (result.RunResult, error) {
 	attempts := 1 + env.retries
 	var (
 		out result.RunResult
@@ -273,7 +281,7 @@ func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, para
 		if env.timeout > 0 {
 			runCtx, cancel = context.WithTimeout(ctx, env.timeout)
 		}
-		out, err = e.runner.Run(runCtx, group, params, e.cfg.Env)
+		out, err = e.runSequence(runCtx, group, commands)
 		cancel()
 		if err == nil {
 			return out, nil
@@ -291,14 +299,49 @@ func (e *Engine) execWithEnvelope(ctx context.Context, group *config.Group, para
 	return out, err
 }
 
+// runSequence executes the group's expanded commands in declared order,
+// stopping at the first failure (like set -e). The returned RunResult
+// aggregates the whole sequence: concatenated streams, summed duration, the
+// exit code of the first failing command (0 when all succeed), and the last
+// runner-reported status. Each command goes to the runner as a copy of the
+// group carrying that command; argv-form entries clear Shell so they always
+// safe-exec, string-form entries keep the group's shell.
+func (e *Engine) runSequence(ctx context.Context, group *config.Group, commands []config.CommandSpec) (result.RunResult, error) {
+	var agg result.RunResult
+	for i, s := range commands {
+		sg := *group
+		sg.Command = s.Command
+		if !s.IsShell {
+			sg.Shell = "" // {command, params} entries are always safe argv exec
+		}
+		out, err := e.runner.Run(ctx, &sg, s.Params, e.cfg.Env)
+		agg.Stdout += out.Stdout
+		agg.Stderr += out.Stderr
+		agg.Output += out.Output
+		agg.DurationMs += out.DurationMs
+		agg.Status = out.Status
+		if agg.ExitCode == 0 {
+			agg.ExitCode = out.ExitCode
+		}
+		if err != nil {
+			// Keep singular-group error strings identical to the pre-multi
+			// behavior; only decorate when there is a sequence to point into.
+			if len(commands) > 1 {
+				err = fmt.Errorf("command %d of %d: %w", i+1, len(commands), err)
+			}
+			return agg, err
+		}
+	}
+	return agg, nil
+}
+
 // cacheLookup returns the stored entry when caching is enabled for the group,
 // the fingerprint matches, and all declared writes still exist.
-func (e *Engine) cacheLookup(group *config.Group, params []string) (*cache.Entry, bool) {
+func (e *Engine) cacheLookup(group *config.Group, commands []config.CommandSpec) (*cache.Entry, bool) {
 	if e.noCache || group.Cache == nil {
 		return nil, false
 	}
-	fp, err := cache.Compute(group.Cache,
-		[]config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}})
+	fp, err := cache.Compute(group.Cache, commands)
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; running group", "group", group.Name, "err", err.Error())
 		return nil, false
@@ -314,12 +357,11 @@ func (e *Engine) cacheLookup(group *config.Group, params []string) (*cache.Entry
 }
 
 // cacheStore persists a fresh cache entry after a successful run.
-func (e *Engine) cacheStore(group *config.Group, params []string, out *result.RunResult) {
+func (e *Engine) cacheStore(group *config.Group, commands []config.CommandSpec, out *result.RunResult) {
 	if e.noCache || group.Cache == nil {
 		return
 	}
-	fp, err := cache.Compute(group.Cache,
-		[]config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}})
+	fp, err := cache.Compute(group.Cache, commands)
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; not caching", "group", group.Name, "err", err.Error())
 		return
@@ -327,7 +369,7 @@ func (e *Engine) cacheStore(group *config.Group, params []string, out *result.Ru
 	entry := &cache.Entry{
 		Fingerprint: fp,
 		Result:      *out,
-		Commands:    []config.CommandSpec{{Command: group.Command, Params: params, IsShell: group.UseShell()}},
+		Commands:    commands,
 		UpdatedAt:   time.Now(),
 	}
 	if err := e.cache.Save(group.Name, entry); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -217,7 +217,6 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 
 	data := template.Data{Outputs: baseline, Env: e.cfg.Env}
 
-	g := *group
 	expanded, err := e.expandCommands(group, data)
 	if err != nil {
 		return err
@@ -226,50 +225,50 @@ func (e *Engine) runGroup(ctx context.Context, group *config.Group, baseline map
 	if e.dryRun {
 		for _, s := range expanded {
 			e.log.Info("[dry-run] would run",
-				"group", g.Name, "command", s.Command, "params", s.Params, "shell", s.IsShell)
+				"group", group.Name, "command", s.Command, "params", s.Params, "shell", s.IsShell)
 		}
-		e.outputs.Set(g.Name, result.RunResult{Status: result.StatusDryRun})
+		e.outputs.Set(group.Name, result.RunResult{Status: result.StatusDryRun})
 		status = StatusDryRun
 		return nil
 	}
 
-	if g.Require != "" {
-		if err = e.prober.Probe(ctx, g.Require, e.cfg.Env); err != nil {
-			return fmt.Errorf("group %q: requirement %q not met: %w", g.Name, g.Require, err)
+	if group.Require != "" {
+		if err = e.prober.Probe(ctx, group.Require, e.cfg.Env); err != nil {
+			return fmt.Errorf("group %q: requirement %q not met: %w", group.Name, group.Require, err)
 		}
 	}
 
-	if g.SkipIf != "" {
-		if err = e.prober.Probe(ctx, g.SkipIf, e.cfg.Env); err == nil {
-			e.outputs.Set(g.Name, result.RunResult{Status: result.StatusSkipped})
-			e.log.Info("group skipped", "group", g.Name, "reason", "skip-if", "predicate", g.SkipIf)
+	if group.SkipIf != "" {
+		if err = e.prober.Probe(ctx, group.SkipIf, e.cfg.Env); err == nil {
+			e.outputs.Set(group.Name, result.RunResult{Status: result.StatusSkipped})
+			e.log.Info("group skipped", "group", group.Name, "reason", "skip-if", "predicate", group.SkipIf)
 			status = StatusSkipped
 			return nil
 		}
 	}
 
-	if fp, hit := e.cacheLookup(&g, expanded); hit {
+	if fp, hit := e.cacheLookup(group, expanded); hit {
 		cached := fp.Result
 		cached.Status = result.StatusCached
-		e.outputs.Set(g.Name, cached)
-		e.log.Info("cache hit", "group", g.Name, "fingerprint", fp.Fingerprint)
+		e.outputs.Set(group.Name, cached)
+		e.log.Info("cache hit", "group", group.Name, "fingerprint", fp.Fingerprint)
 		status = StatusCacheHit
 		return nil
 	}
 
 	for _, s := range expanded {
-		e.log.Info("running group", "group", g.Name, "command", s.Command, "params", s.Params)
+		e.log.Info("running group", "group", group.Name, "command", s.Command, "params", s.Params)
 	}
-	out, err := e.execWithEnvelope(ctx, &g, expanded, env)
+	out, err := e.execWithEnvelope(ctx, group, expanded, env)
 	if err != nil {
-		e.log.Error("group failed", "group", g.Name, "err", err.Error(), "output", out.Output)
+		e.log.Error("group failed", "group", group.Name, "err", err.Error(), "output", out.Output)
 		return err
 	}
-	e.log.Trace("group output", "group", g.Name, "output", out.Output)
+	e.log.Trace("group output", "group", group.Name, "output", out.Output)
 	// Runner sets Status to result.StatusOK on success; trust it so a future
 	// soft-fail Runner can return Status:"failed" without engine clobbering.
-	e.outputs.Set(g.Name, out)
-	e.cacheStore(&g, expanded, &out)
+	e.outputs.Set(group.Name, out)
+	e.cacheStore(group, expanded, &out)
 	return nil
 }
 
@@ -313,9 +312,9 @@ func (e *Engine) execWithEnvelope(
 // stopping at the first failure (like set -e). The returned RunResult
 // aggregates the whole sequence: concatenated streams, summed duration, the
 // exit code of the first failing command (0 when all succeed), and the last
-// runner-reported status. Each command goes to the runner as a copy of the
-// group carrying that command; argv-form entries clear Shell so they always
-// safe-exec, string-form entries keep the group's shell.
+// runner-reported status. Each command goes to the runner as a self-contained
+// copy of the group with exactly one command set; argv-form entries clear
+// Shell so they always safe-exec, string-form entries keep the group's shell.
 func (e *Engine) runSequence(ctx context.Context, group *config.Group, commands []config.CommandSpec) (result.RunResult, error) {
 	var agg result.RunResult
 	for i, s := range commands {
@@ -324,6 +323,8 @@ func (e *Engine) runSequence(ctx context.Context, group *config.Group, commands 
 		}
 		sg := *group
 		sg.Command = s.Command
+		sg.Params = s.Params
+		sg.Commands = nil // the copy presents exactly one command
 		if !s.IsShell {
 			sg.Shell = "" // {command, params} entries are always safe argv exec
 		}
@@ -354,7 +355,7 @@ func (e *Engine) cacheLookup(group *config.Group, commands []config.CommandSpec)
 	if e.noCache || group.Cache == nil {
 		return nil, false
 	}
-	fp, err := cache.Compute(group.Cache, commands)
+	fp, err := cache.Compute(group.Cache, group.Shell, commands)
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; running group", "group", group.Name, "err", err.Error())
 		return nil, false
@@ -374,7 +375,11 @@ func (e *Engine) cacheStore(group *config.Group, commands []config.CommandSpec, 
 	if e.noCache || group.Cache == nil {
 		return
 	}
-	fp, err := cache.Compute(group.Cache, commands)
+	// Recompute rather than reuse cacheLookup's fingerprint: the command may
+	// have rewritten its own cache.reads inputs (e.g. a formatter), and the
+	// stored fingerprint must reflect the post-run input state so the next
+	// run can hit.
+	fp, err := cache.Compute(group.Cache, group.Shell, commands)
 	if err != nil {
 		e.log.Warn("cache fingerprint failed; not caching", "group", group.Name, "err", err.Error())
 		return

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -333,7 +333,12 @@ func (e *Engine) runSequence(ctx context.Context, group *config.Group, commands 
 		agg.Stderr += out.Stderr
 		agg.Output += out.Output
 		agg.DurationMs += out.DurationMs
-		agg.Status = out.Status
+		// First non-ok status wins (mirroring ExitCode): a soft-fail Runner's
+		// Status:"failed" must survive later successful commands, per the
+		// trust-the-runner contract in runGroup.
+		if agg.Status == "" || agg.Status == result.StatusOK {
+			agg.Status = out.Status
+		}
 		if agg.ExitCode == 0 {
 			agg.ExitCode = out.ExitCode
 		}

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -22,7 +22,9 @@ const (
 	defaultPosixSh = "/bin/sh"
 )
 
-// Runner executes a single group and returns its structured RunResult.
+// Runner executes a single group and returns its structured RunResult. The
+// params argument is authoritative for the command's arguments; implementations
+// must not read g.Params or g.Commands.
 type Runner interface {
 	Run(ctx context.Context, g *config.Group, params []string, globalEnv map[string]string) (result.RunResult, error)
 }


### PR DESCRIPTION
## Summary

Adds a polymorphic `commands:` block so one group can run an ordered sequence of commands, with each entry expressible three ways — a safe `{command, params}` argv step, a shell command-line string, or a multiline script — reusing the `RunEntry` string-or-map pattern.

Closes #32

```yaml
groups:
  - name: ci
    shell: bash            # required only for the string/script forms
    commands:
      - { command: go, params: [build, "./..."] }   # safe argv exec (no shell)
      - go test ./...                               # shell command line
      - |                                           # multiline script
        ./scripts/lint.sh --strict
        echo done
```

## Design

- **One internal model.** Singular `command`/`params` stays first-class YAML and normalizes through the new `Group.CommandList()` accessor into a one-element list, so the engine, cache, runner, and structured-output capture share a single execution path — no singular-vs-plural branching anywhere.
- **Form signals mode.** `{command, params}` entries are always safe argv exec and ignore `shell:` even when set; bare/multiline string entries run through the group's `shell:` and are a config-load error without it.
- **Runner untouched.** The engine's new `runSequence` hands the existing `Runner` a per-command copy of the group (`Command` swapped in, `Shell` cleared for argv entries), so singular groups behave byte-identically — logs, error strings, and shell joining included.
- **Stop on first failure.** Commands run in declared order; the first non-zero exit fails the group (like `set -e`). One group → one `RunResult`: `output` is the combined stream in order, `exitCode` is the first failing command's, `durationMs` covers the whole sequence. A retry replays the whole sequence.
- **Cache.** The fingerprint (bumped to v3) folds every command, param, and entry form into the hash — changing any entry busts the cache; pre-v3 entries simply miss once.
- **Refs/templating.** Each entry's command/params expand individually against `{{ output }}` / `{{ env }}`, and `ExtractRefs` walks the full list so refs inside `commands:` entries create DAG edges and step-order checks.

## Validation

- `command` and `commands` on the same group → load error
- string-form entry with no `shell:` → load error
- empty `commands: []` → load error
- `{command, params}` entry with empty command → load error

## Testing

- Table-driven coverage of every form and mix at config (parse/validate), cache (fingerprint), and engine (execution/output) layers, per the issue's test matrix
- Real-`ShellRunner` integration tests prove the load-bearing semantics: argv entries stay injection-safe with `shell:` set (no glob/quote splitting), pipes work in string entries, multiline scripts run as one script, first non-zero exit stops the sequence
- Shared fixture `config-commands-valid.yml` exercised end-to-end by both config and engine tests
- Back-compat regression guard: the entire pre-existing suite passes unmodified; `golangci-lint run ./...` reports 0 issues
- Manual smoke: `keepup validate` + `keepup run` on a mixed-form config prints all five outputs in declared order, exit 0

## Docs

`docs/CONFIG.md` gains a `commands` field row (with the `command` requirement footnote) and a "Multi-command groups" section.

## Out of scope (issue follow-ups)

Per-command `env`/`dir`/`silent` overrides, task composition inside `commands:`, continue-on-error policy.
